### PR TITLE
accept dots in directory name

### DIFF
--- a/src/CSharp App/Services/CacheService.cs
+++ b/src/CSharp App/Services/CacheService.cs
@@ -607,7 +607,7 @@ public class CacheService
         if (fromPath == toPath) return true;
 
         var toPathVr = ValidationService.ValidatePath(toPath);
-        if (toPathVr != ValidationService.PathValidationResult.ValidDirectory)
+        if (toPathVr != ValidationService.PathValidationResult.Valid)
             throw new ArgumentException($"Invalid target path provided: {toPathVr}");
 
         DirectoryInfo fromInfo;
@@ -623,7 +623,7 @@ public class CacheService
         else
         {
             var fromPathVr = ValidationService.ValidatePath(fromPath);
-            if (fromPathVr != ValidationService.PathValidationResult.ValidDirectory)
+            if (fromPathVr != ValidationService.PathValidationResult.Valid)
                 throw new ArgumentException($"Invalid source path provided: {fromPathVr}");
             fromInfo = new DirectoryInfo(fromPath);
             fromExists = fromInfo.Exists;
@@ -810,7 +810,7 @@ public class CacheService
     public CacheDatabaseMetadata GetMetadata()
     {
         string filePath = Path.Combine(_settings.CacheDirectory, "metadata.json");
-        if (ValidationService.ValidatePath(filePath) != ValidationService.PathValidationResult.ValidFile)
+        if (ValidationService.ValidatePath(filePath) != ValidationService.PathValidationResult.Valid)
             throw new Exception("Cache directory is invalid!");
         
         if (File.Exists(filePath))
@@ -821,7 +821,7 @@ public class CacheService
         }
         
         var gameExePath = Path.Combine(_settings.GameDirectory, "bin", "x64", "Cyberpunk2077.exe");
-        if (ValidationService.ValidatePath(filePath) != ValidationService.PathValidationResult.ValidFile)
+        if (ValidationService.ValidatePath(filePath) != ValidationService.PathValidationResult.Valid)
             throw new Exception("Game directory is invalid!");
         
         if (!File.Exists(gameExePath))

--- a/src/CSharp App/Services/LoggerService.cs
+++ b/src/CSharp App/Services/LoggerService.cs
@@ -22,7 +22,7 @@ namespace VolumetricSelection2077.Services
         public static void Initialize(string logDirectory)
         {
             var vR = ValidationService.ValidatePath(logDirectory);
-            if (vR != ValidationService.PathValidationResult.ValidDirectory)
+            if (vR != ValidationService.PathValidationResult.Valid)
                 throw new ArgumentException($"Invalid log directory: {logDirectory}, {vR}");
 
             Directory.CreateDirectory(logDirectory);

--- a/src/CSharp App/Services/PostProcessingService.cs
+++ b/src/CSharp App/Services/PostProcessingService.cs
@@ -324,7 +324,7 @@ public class PostProcessingService
     
     private static string GetOutputFilename(string outputFilename)
     {
-        if (ValidationService.ValidatePath(outputFilename) != ValidationService.PathValidationResult.ValidFile)
+        if (ValidationService.ValidatePath(outputFilename) != ValidationService.PathValidationResult.Valid)
             throw new ArgumentException("Invalid output filename!");
         
         if (!File.Exists(outputFilename))

--- a/src/CSharp App/Services/ProcessService.cs
+++ b/src/CSharp App/Services/ProcessService.cs
@@ -333,7 +333,7 @@ public class ProcessService
     {
         int invalidCount = 0;
         bool invalidRegex = false;
-        if (vr.OutputFileName == ValidationService.PathValidationResult.ValidFile)
+        if (vr.OutputFileName == ValidationService.PathValidationResult.Valid)
             Logger.Success("Filename                 : OK");
         else
         {
@@ -372,7 +372,7 @@ public class ProcessService
             Logger.Success("Selection File           : OK");
         else
         {
-            string invalidReason = vr.SelectionFilePathValidationResult == ValidationService.PathValidationResult.ValidDirectory ? "Not found" : $"Invalid file path {vr.SelectionFilePathValidationResult}";
+            string invalidReason = vr.SelectionFilePathValidationResult == ValidationService.PathValidationResult.Valid ? "Not found" : $"Invalid file path {vr.SelectionFilePathValidationResult}";
             Logger.Error($"Selection File           : {invalidReason}");
             invalidCount++;
         }

--- a/src/CSharp App/Services/UtilService.cs
+++ b/src/CSharp App/Services/UtilService.cs
@@ -105,8 +105,10 @@ namespace VolumetricSelection2077.Services
         /// <exception cref="ArgumentException">given filepath is invalid</exception>
         public static bool IsDirectoryEmpty(string path)
         {
-            if (ValidationService.ValidatePath(path) != ValidationService.PathValidationResult.ValidDirectory)
+            if (ValidationService.ValidatePath(path) != ValidationService.PathValidationResult.Valid)
                 throw new ArgumentException($"Path is invalid.");
+            if (!Directory.Exists(path))
+                throw new ArgumentException($"Path does not exist or is not Directory.");
             if (Directory.EnumerateFiles(path, "*.*", SearchOption.AllDirectories).Any())
                 return false;
             return true;

--- a/src/CSharp App/Services/ValidationService.cs
+++ b/src/CSharp App/Services/ValidationService.cs
@@ -39,7 +39,7 @@ namespace VolumetricSelection2077.Services
         public static (GamePathResult, PathValidationResult) ValidateGamePath(string gamePath)
         {
             var validatePath = ValidatePath(gamePath);
-            if (validatePath != PathValidationResult.ValidDirectory)
+            if (validatePath != PathValidationResult.Valid)
                 return (GamePathResult.InvalidGamePath, validatePath);
             
             string archiveContentPath = Path.Combine(gamePath, "archive", "pc", "content");
@@ -61,7 +61,7 @@ namespace VolumetricSelection2077.Services
         public (bool, PathValidationResult) ValidateSelectionFile(string gamePath)
         {
             var vpr = ValidatePath(gamePath);
-            if (vpr != PathValidationResult.ValidDirectory)
+            if (vpr != PathValidationResult.Valid)
                 return (false, vpr);
             string selectionFilePath;
             if (string.IsNullOrWhiteSpace(_settingsService.CustomSelectionFilePath))
@@ -81,7 +81,7 @@ namespace VolumetricSelection2077.Services
         public static (bool, PathValidationResult) ValidateAndCreateDirectory(string directory)
         {
             var vpr = ValidatePath(directory);
-            if (vpr != PathValidationResult.ValidDirectory)
+            if (vpr != PathValidationResult.Valid)
                 return (false, vpr);
             try
             {
@@ -232,8 +232,7 @@ namespace VolumetricSelection2077.Services
             Drive,
             LeadingOrTrailingSpace,
             TooLong,
-            ValidFile,
-            ValidDirectory
+            Valid
         }
 
         /// <summary>
@@ -258,10 +257,8 @@ namespace VolumetricSelection2077.Services
 
             if (parts.Any(part => part != part.Trim()))
                 return PathValidationResult.LeadingOrTrailingSpace;
-
-            if (Path.HasExtension(path))
-                return PathValidationResult.ValidFile;
-            return PathValidationResult.ValidDirectory;
+            
+            return PathValidationResult.Valid;
         }
         public bool AreVanillaSectorBBsBuild()
         {


### PR DESCRIPTION
validating the filepath no longer distinguishes between file and directory (as it is ambiguous before the file or directory is created) thus allowing dots in the directory path