### PR TITLE
removed debugname from axl removal

### DIFF
--- a/src/CSharp App/Models/AxlRemovalFile.cs
+++ b/src/CSharp App/Models/AxlRemovalFile.cs
@@ -40,7 +40,4 @@ public class AxlRemovalNodeDeletion
     
     [JsonProperty("index")]
     public required int Index { get; set; }
-    
-    [JsonProperty("debugName")]
-    public string? DebugName { get; set; }
 }

--- a/src/CSharp App/Services/ProcessService.cs
+++ b/src/CSharp App/Services/ProcessService.cs
@@ -239,15 +239,13 @@ public class ProcessService
                     {
                         Index = index,
                         Type = nodeEntry.Type.ToString(),
-                        DebugName = nodeEntry.DebugName,
                         ActorDeletions = instances,
                         ExpectedActors = nodeDataEntry.Transforms.Length
                     };
                 return new AxlRemovalNodeDeletion
                 {
                     Index = index,
-                    Type = nodeEntry.Type.ToString(),
-                    DebugName = nodeEntry.DebugName
+                    Type = nodeEntry.Type.ToString()
                 };
             case VEnums.CollisionCheckTypes.Collider:
                 List<int> actorRemoval = new List<int>();
@@ -318,8 +316,7 @@ public class ProcessService
                             Index = index,
                             Type = nodeEntry.Type.ToString(),
                             ActorDeletions = actorRemoval,
-                            ExpectedActors = nodeEntry.Actors.Length,
-                            DebugName = nodeEntry.DebugName
+                            ExpectedActors = nodeEntry.Actors.Length
                         };
                 }
                 return null;
@@ -332,8 +329,7 @@ public class ProcessService
                         return new AxlRemovalNodeDeletion()
                         {
                             Index = index,
-                            Type = nodeEntry.Type.ToString(),
-                            DebugName = nodeEntry.DebugName
+                            Type = nodeEntry.Type.ToString()
                         };
                     }
                 }


### PR DESCRIPTION
removed debug name since it is not required and not used by anything else, which reduced removal file size by 22%