### PR TITLE
improved cache clearing communication

### DIFF
--- a/src/CSharp App/ViewModels/SettingsViewModel.cs
+++ b/src/CSharp App/ViewModels/SettingsViewModel.cs
@@ -57,6 +57,20 @@ namespace VolumetricSelection2077.ViewModels
                 OnPropertyChanged(nameof(AutoUpdateEnabled));
             }
         }
+
+        private bool _cacheWorking;
+        public bool CacheWorking
+        {
+            get => _cacheWorking;
+            set
+            {
+                _cacheWorking = value;
+                OnPropertyChanged(nameof(CacheWorking));
+                OnPropertyChanged(nameof(CacheButtonsAvailable));
+            }
+        }
+        
+        public bool CacheButtonsAvailable => !CacheWorking;
         
         public Bitmap SettingsIcon { get; set; }
         

--- a/src/CSharp App/Views/SettingsWindow.axaml
+++ b/src/CSharp App/Views/SettingsWindow.axaml
@@ -7,6 +7,7 @@
     x:Class="VolumetricSelection2077.SettingsWindow"
     x:DataType="local:ViewModels.SettingsViewModel"
     xmlns="https://github.com/avaloniaui"
+    xmlns:avalonia="clr-namespace:LoadingIndicators.Avalonia;assembly=LoadingIndicators.Avalonia"
     xmlns:controls="clr-namespace:VolumetricSelection2077.Controls"
     xmlns:local="clr-namespace:VolumetricSelection2077"
     xmlns:resources="clr-namespace:VolumetricSelection2077.Resources"
@@ -172,6 +173,7 @@
                     Grid.Column="0"
                     HorizontalAlignment="Stretch"
                     HorizontalContentAlignment="Center"
+                    IsEnabled="{Binding CacheButtonsAvailable}"
                     Margin="5,0,0,0">
                     <Button.Styles>
                         <Style Selector="Button:pointerover /template/ ContentPresenter">
@@ -179,6 +181,13 @@
                         </Style>
                     </Button.Styles>
                 </Button>
+                <Grid Grid.Column="0" IsVisible="{Binding CacheWorking}">
+                    <avalonia:LoadingIndicator
+                        Foreground="White"
+                        Height="30"
+                        IsActive="True"
+                        Width="30" />
+                </Grid>
                 <Button
                     Background="#ad0002"
                     Click="ClearModdedCache_Click"
@@ -186,6 +195,7 @@
                     Grid.Column="1"
                     HorizontalAlignment="Stretch"
                     HorizontalContentAlignment="Center"
+                    IsEnabled="{Binding CacheButtonsAvailable}"
                     Margin="5,0,0,0">
                     <Button.Styles>
                         <Style Selector="Button:pointerover /template/ ContentPresenter">
@@ -193,6 +203,13 @@
                         </Style>
                     </Button.Styles>
                 </Button>
+                <Grid Grid.Column="1" IsVisible="{Binding CacheWorking}">
+                    <avalonia:LoadingIndicator
+                        Foreground="White"
+                        Height="30"
+                        IsActive="True"
+                        Width="30" />
+                </Grid>
             </Grid>
             <Grid Grid.Column="1" Grid.Row="10">
                 <Grid.ColumnDefinitions>*, *</Grid.ColumnDefinitions>
@@ -203,6 +220,7 @@
                     Grid.Column="0"
                     HorizontalAlignment="Stretch"
                     HorizontalContentAlignment="Center"
+                    IsEnabled="{Binding CacheButtonsAvailable}"
                     Margin="5,0,0,0">
                     <Button.Styles>
                         <Style Selector="Button:pointerover /template/ ContentPresenter">
@@ -210,6 +228,13 @@
                         </Style>
                     </Button.Styles>
                 </Button>
+                <Grid Grid.Column="0" IsVisible="{Binding CacheWorking}">
+                    <avalonia:LoadingIndicator
+                        Foreground="White"
+                        Height="30"
+                        IsActive="True"
+                        Width="30" />
+                </Grid>
                 <Button
                     Background="#ad0002"
                     Click="ClearModdedBoundsCache_Click"
@@ -217,6 +242,7 @@
                     Grid.Column="1"
                     HorizontalAlignment="Stretch"
                     HorizontalContentAlignment="Center"
+                    IsEnabled="{Binding CacheButtonsAvailable}"
                     Margin="5,0,0,0">
                     <Button.Styles>
                         <Style Selector="Button:pointerover /template/ ContentPresenter">
@@ -224,6 +250,13 @@
                         </Style>
                     </Button.Styles>
                 </Button>
+                <Grid Grid.Column="1" IsVisible="{Binding CacheWorking}">
+                    <avalonia:LoadingIndicator
+                        Foreground="White"
+                        Height="30"
+                        IsActive="True"
+                        Width="30" />
+                </Grid>
             </Grid>
             <TextBox
                 Grid.Column="1"

--- a/src/CSharp App/Views/SettingsWindow.axaml.cs
+++ b/src/CSharp App/Views/SettingsWindow.axaml.cs
@@ -65,28 +65,36 @@ namespace VolumetricSelection2077
         private async void ClearVanillaCache_Click(object sender, RoutedEventArgs e)
         {
             if(!_cacheService.IsInitialized) return;
+            _settingsViewModel.CacheWorking = true;
             await Task.Run(() => _cacheService.ClearDatabase(CacheDatabases.Vanilla));
+            _settingsViewModel.CacheWorking = false;
             UpdateCacheStats();
         }
         
         private async void ClearModdedCache_Click(object sender, RoutedEventArgs e)
         {
             if(!_cacheService.IsInitialized) return;
+            _settingsViewModel.CacheWorking = true;
             await Task.Run(() => _cacheService.ClearDatabase(CacheDatabases.Modded));
+            _settingsViewModel.CacheWorking = false;
             UpdateCacheStats();
         }
         
         private async void ClearVanillaBoundsCache_Click(object sender, RoutedEventArgs e)
         {
             if(!_cacheService.IsInitialized) return;
+            _settingsViewModel.CacheWorking = true;
             await Task.Run(() => _cacheService.ClearDatabase(CacheDatabases.VanillaBounds));
+            _settingsViewModel.CacheWorking = false;
             UpdateCacheStats();
         }
         
         private async void ClearModdedBoundsCache_Click(object sender, RoutedEventArgs e)
         {
             if(!_cacheService.IsInitialized) return;
+            _settingsViewModel.CacheWorking = true;
             await Task.Run(() => _cacheService.ClearDatabase(CacheDatabases.ModdedBounds));
+            _settingsViewModel.CacheWorking = false;
             UpdateCacheStats();
         }
 


### PR DESCRIPTION
when clearing the cache from the settings it now disables the buttons and shows a loading spinner indicating that it is doing something as large caches especially on hard drives may take a few seconds to clear