### PR TITLE
User controlled physical mesh treatment

### DIFF
--- a/src/CSharp App/Enums/DestructibleMeshTreatment.cs
+++ b/src/CSharp App/Enums/DestructibleMeshTreatment.cs
@@ -1,0 +1,7 @@
+namespace VolumetricSelection2077.Enums;
+
+public enum DestructibleMeshTreatment
+{
+    DynamicMesh,
+    StaticMesh
+}

--- a/src/CSharp App/Resources/Descriptions.cs
+++ b/src/CSharp App/Resources/Descriptions.cs
@@ -25,6 +25,7 @@ namespace VolumetricSelection2077.Resources
             public static string CustomSelectionFilePath { get; } = "Path to the custom selection file location (e.g. MO2's overwrite folder). The same folder structure as found in the game directory is expected. If selection file is in the game directory leave this blank.";
             public static string MaxBackupFiles { get; } = "Maximum number of backup files to keep, older files will be deleted. Does not affect the output directory.";
             public static string BackupDirectory { get; } = "Directory to save backups of the selection and output after every run.";
+            public static string DestructibleMeshTreatment { get; } = "Whether to save destructible meshes as dynamic meshes (with physics, but limited filtering) or as static meshes (no physics). Only affects World Builder output.";
         }
 
         public static class Watermarks
@@ -59,5 +60,6 @@ namespace VolumetricSelection2077.Resources
             public static string CustomSelectionFilePath { get; } = "MO2 Overwrite Folder";
             public static string BackupDirectory { get; } = "Backup Directory";
             public static string MaxBackupFiles { get; } = "Max Backup Files";
+            public static string  DestructibleMeshTreatment { get; } = "Destructible Mesh Treatment";
         }
 }

--- a/src/CSharp App/Services/SettingsService.cs
+++ b/src/CSharp App/Services/SettingsService.cs
@@ -35,6 +35,7 @@ public class SettingsService
         IsFiltersMWVisible = false;
         IsParametersMWVisible = false;
         SaveFileFormat = SaveFileFormat.ArchiveXLJson;
+        DestructibleMeshTreatment = DestructibleMeshTreatment.DynamicMesh;
         SaveMode = SaveFileMode.New;
         SupportModdedResources = false;
         CacheModdedResources = true;
@@ -63,8 +64,7 @@ public class SettingsService
             }
         }
     }
-
-    // Properties
+    
     public string GameDirectory { get; set; }
     public bool CacheEnabled { get; set; }
     public string CacheDirectory { get; set; }
@@ -94,6 +94,7 @@ public class SettingsService
     public bool IsFiltersMWVisible { get; set; }
     public bool IsParametersMWVisible { get; set; }
     public SaveFileMode SaveMode { get; set; }
+    public DestructibleMeshTreatment DestructibleMeshTreatment { get; set; }
     public bool AutoUpdate { get; set; }
     public bool DidUpdate { get; set; }
     public bool GameRunningDuringUpdate { get; set; }
@@ -163,8 +164,7 @@ public class SettingsService
 
                 SaveMode = (SaveFileMode?)j.Value<long?>(nameof(SaveMode)) ?? SaveMode;
                 SaveFileFormat = (SaveFileFormat?)j.Value<long?>(nameof(SaveFileFormat)) ?? SaveFileFormat;
-                
-                
+                DestructibleMeshTreatment = (DestructibleMeshTreatment?)j.Value<long?>(nameof(DestructibleMeshTreatment)) ?? DestructibleMeshTreatment;
                 
                 SupportModdedResources = j.Value<bool?>(nameof(SupportModdedResources)) ?? SupportModdedResources;
                 AutoUpdate = j.Value<bool?>(nameof(AutoUpdate)) ?? AutoUpdate;

--- a/src/CSharp App/ViewModels/MainWindowViewModel.cs
+++ b/src/CSharp App/ViewModels/MainWindowViewModel.cs
@@ -184,6 +184,19 @@ namespace VolumetricSelection2077.ViewModels
             }
         }
         
+        public ObservableCollection<DestructibleMeshTreatment> DestructibleMeshTreatments { get; set; }
+
+        public DestructibleMeshTreatment SelectedDestructibleMeshTreatment
+        {
+            get => Settings.DestructibleMeshTreatment;
+            set
+            {
+                Settings.DestructibleMeshTreatment = value;
+                OnPropertyChanged(nameof(SelectedDestructibleMeshTreatment));
+                Settings.SaveSettings();
+            }
+        }
+        
         public MainWindowViewModel()
         {
             Settings = SettingsService.Instance;
@@ -204,6 +217,7 @@ namespace VolumetricSelection2077.ViewModels
             SaveFileModes = new ObservableCollection<SaveFileMode>(Enum.GetValues(typeof(SaveFileMode)).Cast<SaveFileMode>());
             SaveFileFormats = new ObservableCollection<SaveFileFormat>(Enum.GetValues(typeof(SaveFileFormat)).Cast<SaveFileFormat>());
             SaveFileLocations = new ObservableCollection<SaveFileLocation>(Enum.GetValues(typeof(SaveFileLocation)).Cast<SaveFileLocation>());
+            DestructibleMeshTreatments = new ObservableCollection<DestructibleMeshTreatment>(Enum.GetValues(typeof(DestructibleMeshTreatment)).Cast<DestructibleMeshTreatment>());
             
             try
             {

--- a/src/CSharp App/Views/MainWindow.axaml
+++ b/src/CSharp App/Views/MainWindow.axaml
@@ -339,6 +339,23 @@
                         ItemsSource="{Binding SaveFileModes}"
                         Margin="5"
                         SelectedItem="{Binding SelectedSaveFileMode, Mode=TwoWay}" />
+                    <TextBlock
+                        Grid.Column="0"
+                        Grid.Row="1"
+                        HorizontalAlignment="Left"
+                        IsVisible="{Binding ParameterSelectionVisibility}"
+                        Margin="5"
+                        Text="{x:Static resources:Labels.DestructibleMeshTreatment}"
+                        ToolTip.Tip="{x:Static resources:ToolTips.DestructibleMeshTreatment}"
+                        VerticalAlignment="Center" />
+                    <ComboBox
+                        Grid.Column="1"
+                        Grid.Row="1"
+                        HorizontalAlignment="Stretch"
+                        IsVisible="{Binding ParameterSelectionVisibility}"
+                        ItemsSource="{Binding DestructibleMeshTreatments}"
+                        Margin="5"
+                        SelectedItem="{Binding SelectedDestructibleMeshTreatment, Mode=TwoWay}" />
                 </Grid>
             </Grid>
             <Grid Grid.Row="6" Margin="5">


### PR DESCRIPTION
## User controlled physical mesh treatment

### Adds
* drop down setting to let user choose between saving meshes with physics as dynamic meshes (with physics but limited filtering) or as static meshes (no physics). Only applies to exporting as a world builder prefab
