### PR TITLE
added buttons to open folders directly in the settings view

### DIFF
--- a/src/CSharp App/App.axaml.cs
+++ b/src/CSharp App/App.axaml.cs
@@ -2,6 +2,7 @@ using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
 using VolumetricSelection2077.Services;
+using VolumetricSelection2077.Views;
 
 namespace VolumetricSelection2077;
 

--- a/src/CSharp App/Resources/Descriptions.cs
+++ b/src/CSharp App/Resources/Descriptions.cs
@@ -61,5 +61,6 @@ namespace VolumetricSelection2077.Resources
             public static string BackupDirectory { get; } = "Backup Directory";
             public static string MaxBackupFiles { get; } = "Max Backup Files";
             public static string  DestructibleMeshTreatment { get; } = "Destructible Mesh Treatment";
+            public static string Open { get; } = "Open";
         }
 }

--- a/src/CSharp App/Services/OSUtilsService.cs
+++ b/src/CSharp App/Services/OSUtilsService.cs
@@ -1,0 +1,17 @@
+using System.Diagnostics;
+
+namespace VolumetricSelection2077.Services;
+
+/// <summary>
+/// Currently only supports Windows, created to gather all the OS specific code in one place (except UpdateService)
+/// </summary>
+public class OsUtilsService
+{
+    public static void OpenFolder(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return;
+        
+        Process.Start(new ProcessStartInfo("explorer.exe", $"\"{path}\"") { UseShellExecute = true });
+    }
+}

--- a/src/CSharp App/Views/SettingsWindow.axaml
+++ b/src/CSharp App/Views/SettingsWindow.axaml
@@ -118,13 +118,31 @@
                 ToolTip.Tip="{x:Static resources:ToolTips.MaxBackupFiles}"
                 VerticalAlignment="Center" />
             <!--  Second Row: Setting Control (e.g., ToggleSwitch)  -->
-            <TextBox
+            <Grid
+                ColumnDefinitions="*, Auto"
                 Grid.Column="1"
                 Grid.Row="1"
-                Margin="5"
-                Text="{Binding Settings.GameDirectory}"
-                Watermark="{x:Static resources:Watermarks.GameDirectory}"
-                x:Name="GameDirectoryTextBox" />
+                RowDefinitions="Auto">
+                <TextBox
+                    Grid.Column="0"
+                    Grid.Row="0"
+                    Margin="5"
+                    Text="{Binding Settings.GameDirectory}"
+                    Watermark="{x:Static resources:Watermarks.GameDirectory}" />
+                <Button
+                    Background="#6b82b2"
+                    Click="OpenGameDir_Click"
+                    Content="{x:Static resources:Labels.Open}"
+                    Grid.Column="1"
+                    Grid.Row="0"
+                    Margin="0,0,5,0">
+                    <Button.Styles>
+                        <Style Selector="Button:pointerover /template/ ContentPresenter">
+                            <Setter Property="Background" Value="#455472" />
+                        </Style>
+                    </Button.Styles>
+                </Button>
+            </Grid>
             <ToggleSwitch
                 Grid.Column="1"
                 Grid.Row="2"
@@ -139,19 +157,57 @@
                 Margin="5"
                 OffContent=""
                 OnContent="" />
-            <TextBox
+            <Grid
+                ColumnDefinitions="*, Auto"
                 Grid.Column="1"
                 Grid.Row="5"
                 IsVisible="{Binding AutoUpdateEnabled}"
-                Margin="5"
-                Text="{Binding Settings.CETInstallLocation}"
-                Watermark="{x:Static resources:Watermarks.CETInstallLocation}" />
-            <TextBox
+                RowDefinitions="Auto">
+                <TextBox
+                    Grid.Column="0"
+                    Grid.Row="0"
+                    Margin="5"
+                    Text="{Binding Settings.CETInstallLocation}"
+                    Watermark="{x:Static resources:Watermarks.CETInstallLocation}" />
+                <Button
+                    Background="#6b82b2"
+                    Click="OpenCETDir_Click"
+                    Content="{x:Static resources:Labels.Open}"
+                    Grid.Column="1"
+                    Grid.Row="0"
+                    Margin="0,0,5,0">
+                    <Button.Styles>
+                        <Style Selector="Button:pointerover /template/ ContentPresenter">
+                            <Setter Property="Background" Value="#455472" />
+                        </Style>
+                    </Button.Styles>
+                </Button>
+            </Grid>
+            <Grid
+                ColumnDefinitions="*, Auto"
                 Grid.Column="1"
                 Grid.Row="6"
-                Margin="5"
-                Text="{Binding Settings.OutputDirectory}"
-                Watermark="{x:Static resources:Watermarks.CustomOutputDirectory}" />
+                RowDefinitions="Auto">
+                <TextBox
+                    Grid.Column="0"
+                    Grid.Row="0"
+                    Margin="5"
+                    Text="{Binding Settings.OutputDirectory}"
+                    Watermark="{x:Static resources:Watermarks.CustomOutputDirectory}" />
+                <Button
+                    Background="#6b82b2"
+                    Click="OpenOutputDir_Click"
+                    Content="{x:Static resources:Labels.Open}"
+                    Grid.Column="1"
+                    Grid.Row="0"
+                    Margin="0,0,5,0">
+                    <Button.Styles>
+                        <Style Selector="Button:pointerover /template/ ContentPresenter">
+                            <Setter Property="Background" Value="#455472" />
+                        </Style>
+                    </Button.Styles>
+                </Button>
+            </Grid>
             <ToggleSwitch
                 Grid.Column="1"
                 Grid.Row="7"
@@ -159,12 +215,31 @@
                 Margin="5"
                 OffContent=""
                 OnContent="" />
-            <TextBox
+            <Grid
+                ColumnDefinitions="*, Auto"
                 Grid.Column="1"
                 Grid.Row="8"
-                Margin="5"
-                Text="{Binding Settings.CacheDirectory}"
-                Watermark="{x:Static resources:Watermarks.CacheDirectory}" />
+                RowDefinitions="Auto">
+                <TextBox
+                    Grid.Column="0"
+                    Grid.Row="0"
+                    Margin="5"
+                    Text="{Binding Settings.CacheDirectory}"
+                    Watermark="{x:Static resources:Watermarks.CacheDirectory}" />
+                <Button
+                    Background="#6b82b2"
+                    Click="OpenCacheDir_Click"
+                    Content="{x:Static resources:Labels.Open}"
+                    Grid.Column="1"
+                    Grid.Row="0"
+                    Margin="0,0,5,0">
+                    <Button.Styles>
+                        <Style Selector="Button:pointerover /template/ ContentPresenter">
+                            <Setter Property="Background" Value="#455472" />
+                        </Style>
+                    </Button.Styles>
+                </Button>
+            </Grid>
             <Grid Grid.Column="1" Grid.Row="9">
                 <Grid.ColumnDefinitions>*, *</Grid.ColumnDefinitions>
                 <Button
@@ -197,7 +272,7 @@
                     HorizontalAlignment="Stretch"
                     HorizontalContentAlignment="Center"
                     IsEnabled="{Binding CacheButtonsAvailable}"
-                    Margin="5,0,0,0">
+                    Margin="5,0,5,0">
                     <Button.Styles>
                         <Style Selector="Button:pointerover /template/ ContentPresenter">
                             <Setter Property="Background" Value="DarkRed" />
@@ -244,7 +319,7 @@
                     HorizontalAlignment="Stretch"
                     HorizontalContentAlignment="Center"
                     IsEnabled="{Binding CacheButtonsAvailable}"
-                    Margin="5,0,0,0">
+                    Margin="5,0,5,0">
                     <Button.Styles>
                         <Style Selector="Button:pointerover /template/ ContentPresenter">
                             <Setter Property="Background" Value="DarkRed" />
@@ -259,18 +334,56 @@
                         Width="30" />
                 </Grid>
             </Grid>
-            <TextBox
+            <Grid
+                ColumnDefinitions="*, Auto"
                 Grid.Column="1"
                 Grid.Row="11"
-                Margin="5"
-                Text="{Binding Settings.CustomSelectionFilePath}"
-                Watermark="{x:Static resources:Labels.CustomSelectionFilePath}" />
-            <TextBox
+                RowDefinitions="Auto">
+                <TextBox
+                    Grid.Column="0"
+                    Grid.Row="0"
+                    Margin="5"
+                    Text="{Binding Settings.CustomSelectionFilePath}"
+                    Watermark="{x:Static resources:Labels.CustomSelectionFilePath}" />
+                <Button
+                    Background="#6b82b2"
+                    Click="OpenCustomSelectionDir_Click"
+                    Content="{x:Static resources:Labels.Open}"
+                    Grid.Column="1"
+                    Grid.Row="0"
+                    Margin="0,0,5,0">
+                    <Button.Styles>
+                        <Style Selector="Button:pointerover /template/ ContentPresenter">
+                            <Setter Property="Background" Value="#455472" />
+                        </Style>
+                    </Button.Styles>
+                </Button>
+            </Grid>
+            <Grid
+                ColumnDefinitions="*, Auto"
                 Grid.Column="1"
                 Grid.Row="12"
-                Margin="5"
-                Text="{Binding Settings.BackupDirectory}"
-                Watermark="{x:Static resources:Labels.BackupDirectory}" />
+                RowDefinitions="Auto">
+                <TextBox
+                    Grid.Column="0"
+                    Grid.Row="0"
+                    Margin="5"
+                    Text="{Binding Settings.BackupDirectory}"
+                    Watermark="{x:Static resources:Labels.BackupDirectory}" />
+                <Button
+                    Background="#6b82b2"
+                    Click="OpenBackupDir_Click"
+                    Content="{x:Static resources:Labels.Open}"
+                    Grid.Column="1"
+                    Grid.Row="0"
+                    Margin="0,0,5,0">
+                    <Button.Styles>
+                        <Style Selector="Button:pointerover /template/ ContentPresenter">
+                            <Setter Property="Background" Value="#455472" />
+                        </Style>
+                    </Button.Styles>
+                </Button>
+            </Grid>
             <controls:Int32TextBox
                 Grid.Column="1"
                 Grid.Row="13"

--- a/src/CSharp App/Views/SettingsWindow.axaml.cs
+++ b/src/CSharp App/Views/SettingsWindow.axaml.cs
@@ -83,6 +83,36 @@ namespace VolumetricSelection2077.Views
             UpdateCacheStats();
         }
 
+        private void OpenBackupDir_Click(object sender, RoutedEventArgs e)
+        {
+            OsUtilsService.OpenFolder(_settingsViewModel.Settings.BackupDirectory);
+        }
+        
+        private void OpenCustomSelectionDir_Click(object sender, RoutedEventArgs e)
+        {
+            OsUtilsService.OpenFolder(_settingsViewModel.Settings.CustomSelectionFilePath);
+        }
+        
+        private void OpenCacheDir_Click(object sender, RoutedEventArgs e)
+        {
+            OsUtilsService.OpenFolder(_settingsViewModel.Settings.CacheDirectory);
+        }
+        
+        private void OpenOutputDir_Click(object sender, RoutedEventArgs e)
+        {
+            OsUtilsService.OpenFolder(_settingsViewModel.Settings.OutputDirectory);
+        }
+
+        private void OpenCETDir_Click(object sender, RoutedEventArgs e)
+        {
+            OsUtilsService.OpenFolder(_settingsViewModel.Settings.CETInstallLocation);
+        }
+        
+        private void OpenGameDir_Click(object sender, RoutedEventArgs e)
+        {
+            OsUtilsService.OpenFolder(_settingsViewModel.Settings.GameDirectory);
+        }
+
         private async void OnSettingsWindowClosing(object? sender, System.ComponentModel.CancelEventArgs e)
         {
             if (_showedDialog || !_settingsViewModel.PersistentCache.CachePathChanged)


### PR DESCRIPTION
## added buttons to open folders directly in the settings view

### Adds
* Buttons to quickly open the given folder
* OsUtilService for encapsulating most OS dependent operations (currently only supports windows) 

### Screenshots / Notes
<img width="139" height="503" alt="image" src="https://github.com/user-attachments/assets/c9e2e1d7-2038-4317-87c8-e84c12bd0f84" />
