### PR TITLE
reduce log level to debug for sector process progress

### DIFF
--- a/src/CSharp App/Services/BoundingBoxBuilderService.cs
+++ b/src/CSharp App/Services/BoundingBoxBuilderService.cs
@@ -87,7 +87,7 @@ public class BoundingBoxBuilderService
     {
         try
         {
-            Logger.Info($"Building bounds for {sectorPath}...");
+            Logger.Debug($"Building bounds for {sectorPath}...");
             var sector = _gameFileService.GetSector(sectorPath);
             if (sector == null)
             {

--- a/src/CSharp App/Services/ProcessService.cs
+++ b/src/CSharp App/Services/ProcessService.cs
@@ -99,7 +99,7 @@ public class ProcessService
     
     private async Task<AxlRemovalSector?> SectorProcessThread(string streamingSectorName, SelectionInput CETOutputFile)
     {
-        Logger.Info($"Starting sector process thread for {streamingSectorName}...");
+        Logger.Debug($"Starting sector process thread for {streamingSectorName}...");
         try
         {
             string streamingSectorNameFix = Regex.Replace(streamingSectorName, @"\\{2}", @"\");
@@ -113,7 +113,7 @@ public class ProcessService
             var (successPSS, errorPSS, resultPss) = await ProcessStreamingsector(sector, streamingSectorName, CETOutputFile);
             if (successPSS)
             { 
-                Logger.Info($"Successfully processed streamingsector {streamingSectorName} which found {resultPss?.NodeDeletions.Count ?? 0} nodes out of {sector.NodeData.Length} nodes.");
+                Logger.Debug($"Successfully processed streamingsector {streamingSectorName} which found {resultPss?.NodeDeletions.Count ?? 0} nodes out of {sector.NodeData.Length} nodes.");
                 return resultPss;
             }
             


### PR DESCRIPTION
## reduce log level to debug for sector process progress
### Improves
* Log Readability and performance by reducing unnecessary logging of individual sectors unless debug mode is enabled 
(The progress bar and timer are more than enough to convey progress to the user) 
