### PR TITLE
Feat skip known bad sectors

### DIFF
--- a/src/CSharp App/Converters/Complex/AxlRemovalToWorldBuilderConverter.cs
+++ b/src/CSharp App/Converters/Complex/AxlRemovalToWorldBuilderConverter.cs
@@ -208,7 +208,7 @@ public class AxlRemovalToWorldBuilderConverter
 
                 HandleEmbeddedResourceWarning(foliageNode.Mesh.DepotPath, sectorPath, ref sectorCR2W);
                 
-                worldSectorAbbr ??= _gfs.GetSector(sectorPath);
+                worldSectorAbbr ??= _gfs.GetSector(sectorPath).Resource as AbbrSector;
                 if (worldSectorAbbr == null)
                     return spawnableElements;
                 var abbrFoliageNodeNodeDataEntry = worldSectorAbbr.NodeData[remNode.Index];
@@ -245,7 +245,7 @@ public class AxlRemovalToWorldBuilderConverter
 
                 HandleEmbeddedResourceWarning(instancedDestructibleMeshNode.Mesh.DepotPath, sectorPath, ref sectorCR2W);
                 
-                worldSectorAbbr ??= _gfs.GetSector(sectorPath);
+                worldSectorAbbr ??= _gfs.GetSector(sectorPath).Resource as AbbrSector;
                 if (worldSectorAbbr == null)
                     return spawnableElements;
                 var abbrInstancedDestructibleMeshNodeDataEntry = worldSectorAbbr.NodeData[remNode.Index];
@@ -542,7 +542,7 @@ public class AxlRemovalToWorldBuilderConverter
 
                 HandleEmbeddedResourceWarning(instancedMeshNode.Mesh.DepotPath, sectorPath, ref sectorCR2W);
                 
-                worldSectorAbbr ??= _gfs.GetSector(sectorPath);
+                worldSectorAbbr ??= _gfs.GetSector(sectorPath).Resource as AbbrSector;
                 if (worldSectorAbbr == null)
                     return spawnableElements;
                 var abbrInstancedMeshNodeDataEntry = worldSectorAbbr.NodeData[remNode.Index];

--- a/src/CSharp App/Enums/ResourceTokenResult.cs
+++ b/src/CSharp App/Enums/ResourceTokenResult.cs
@@ -1,0 +1,9 @@
+namespace VolumetricSelection2077.Enums;
+
+public enum ResourceTokenResult
+{
+    Success, 
+    Failure,
+    KnownBad,
+    NotInitialized
+}

--- a/src/CSharp App/Models/ResourceToken.cs
+++ b/src/CSharp App/Models/ResourceToken.cs
@@ -1,0 +1,9 @@
+using VolumetricSelection2077.Enums;
+
+namespace VolumetricSelection2077.Models;
+
+public struct ResourceToken
+{
+    public ResourceTokenResult Result { get; set; }
+    public object? Resource { get; set; }
+}

--- a/src/CSharp App/Resources/Descriptions.cs
+++ b/src/CSharp App/Resources/Descriptions.cs
@@ -26,6 +26,7 @@ namespace VolumetricSelection2077.Resources
             public static string MaxBackupFiles { get; } = "Maximum number of backup files to keep, older files will be deleted. Does not affect the output directory.";
             public static string BackupDirectory { get; } = "Directory to save backups of the selection and output after every run.";
             public static string DestructibleMeshTreatment { get; } = "Whether to save destructible meshes as dynamic meshes (with physics, but limited filtering) or as static meshes (no physics). Only affects World Builder output.";
+            public static string RememberFailedResources { get; } = "Remembers resources that fail and skips them from then on.";
         }
 
         public static class Watermarks
@@ -61,5 +62,6 @@ namespace VolumetricSelection2077.Resources
             public static string MaxBackupFiles { get; } = "Max Backup Files";
             public static string  DestructibleMeshTreatment { get; } = "Destructible Mesh Treatment";
             public static string AutoScroll { get; } = "Auto Scroll";
+            public static string RememberFailedResources { get; } = "Clear Known Bad Resources";
         }
 }

--- a/src/CSharp App/Services/BoundingBoxBuilderService.cs
+++ b/src/CSharp App/Services/BoundingBoxBuilderService.cs
@@ -88,10 +88,17 @@ public class BoundingBoxBuilderService
         try
         {
             Logger.Info($"Building bounds for {sectorPath}...");
-            var sector = _gameFileService.GetSector(sectorPath);
-            if (sector == null)
+            var sectorToken = _gameFileService.GetSector(sectorPath);
+            if (sectorToken.Resource is not AbbrSector sector)
             {
-                Logger.Warning($"Failed to get sector {sectorPath}");
+                switch (sectorToken.Result)
+                {
+                    case VEnums.ResourceTokenResult.KnownBad: Logger.Warning($"Sector {sectorPath} is a known bad resource, skipping..."); break;
+                    case VEnums.ResourceTokenResult.Success: Logger.Error($"Received an unexpected resource type {sectorToken.Resource?.GetType()} for sector {sectorPath}"); break;
+                    case VEnums.ResourceTokenResult.Failure: Logger.Error($"Failed to get sector {sectorPath}"); break;
+                    case VEnums.ResourceTokenResult.NotInitialized: Logger.Error($"GameFileService not initialized, cannot get sector {sectorPath}"); break;
+                    default: Logger.Error($"Unknown resource token result {sectorToken.Result} for sector {sectorPath}"); break;
+                }
                 return;
             }
 
@@ -104,10 +111,17 @@ public class BoundingBoxBuilderService
                 
                 if ((nodeEntry?.ResourcePath?.EndsWith(".mesh") ?? false) || (nodeEntry?.ResourcePath?.EndsWith(".w2mesh") ?? false))
                 {
-                    var mesh = _gameFileService.GetCMesh(nodeEntry.ResourcePath);
-                    if (mesh == null)
+                    var meshToken = _gameFileService.GetCMesh(nodeEntry.ResourcePath);
+                    if (meshToken.Resource is not AbbrMesh mesh)
                     {
-                        Logger.Warning($"Failed to get CMesh from {nodeEntry.ResourcePath}, using only position data");
+                        switch (meshToken.Result)
+                        {
+                            case VEnums.ResourceTokenResult.KnownBad: Logger.Warning($"Mesh {nodeEntry.ResourcePath} is a known bad resource, using only position data"); break;
+                            case VEnums.ResourceTokenResult.Success: Logger.Warning($"Received an unexpected resource type {meshToken.Resource?.GetType()} for mesh {nodeEntry.ResourcePath}, using only position data"); break;
+                            case VEnums.ResourceTokenResult.Failure: Logger.Warning($"Failed to get mesh {nodeEntry.ResourcePath}, using only position data"); break;
+                            case VEnums.ResourceTokenResult.NotInitialized: Logger.Error($"GameFileService not initialized, cannot get mesh {nodeEntry.ResourcePath}, using only position data"); break;
+                            default: Logger.Warning($"Unknown resource token result {meshToken.Result} for mesh {nodeEntry.ResourcePath}, using only position data"); break;
+                        }
                         foreach (var transform in nodeDataEntry.Transforms)
                         {
                             min = Vector3.Min(min, transform.Position);
@@ -151,12 +165,28 @@ public class BoundingBoxBuilderService
                             {
                                 case WEnums.physicsShapeType.TriangleMesh:
                                 case WEnums.physicsShapeType.ConvexMesh:
-                                    var collisionMesh = await _gameFileService.GetPhysXMesh((ulong)nodeEntry.SectorHash,
-                                        (ulong)shape.Hash);
-                                    if (collisionMesh == null)
+                                    if (nodeEntry.SectorHash is not ulong sectorHash ||
+                                        shape.Hash is not ulong shapeHash)
                                     {
-                                        Logger.Warning(
-                                            $"Failed to get PhysX Mesh from {(ulong)nodeEntry.SectorHash} : {shape.Hash}, using only position data");
+                                        Logger.Warning($"Node Data entry contains invalid sector hash {nodeEntry.SectorHash} or shape hash {shape.Hash}, using only position data");
+                                        var combinedPosition = shape.Transform.Position + actor.Transform.Position;
+                                        min = Vector3.Min(min, combinedPosition);
+                                        max = Vector3.Max(max, combinedPosition);
+                                        continue;
+                                    }
+                                    
+                                    var collisionMeshToken = await _gameFileService.GetPhysXMesh(sectorHash,
+                                        shapeHash);
+                                    if (collisionMeshToken.Resource is not AbbrMesh collisionMesh)
+                                    {
+                                        switch (collisionMeshToken.Result)
+                                        {
+                                            case VEnums.ResourceTokenResult.KnownBad: Logger.Warning($"Collision mesh at sector hash {sectorHash} : shape hash {shapeHash} is a known bad resource, using only position data"); break;
+                                            case VEnums.ResourceTokenResult.Success: Logger.Warning($"Received an unexpected resource type {collisionMeshToken.Resource?.GetType()} for sector hash {sectorHash} : shape hash {shapeHash}, using only position data"); break;
+                                            case VEnums.ResourceTokenResult.Failure: Logger.Warning($"Failed to get collision mesh at sector hash {sectorHash} : shape hash {shapeHash}, using only position data"); break;
+                                            case VEnums.ResourceTokenResult.NotInitialized: Logger.Error($"GameFileService not initialized, cannot get collision mesh at sector hash {sectorHash} : shape hash {shapeHash}"); break;
+                                            default: Logger.Warning($"Unknown resource token result {collisionMeshToken.Result} for collision mesh at sector hash {sectorHash} : shape hash {shapeHash}, using only position data"); break;
+                                        }
                                         var combinedPosition = shape.Transform.Position + actor.Transform.Position;
                                         min = Vector3.Min(min, combinedPosition);
                                         max = Vector3.Max(max, combinedPosition);

--- a/src/CSharp App/Services/CacheService.cs
+++ b/src/CSharp App/Services/CacheService.cs
@@ -602,7 +602,13 @@ public partial class CacheService
             File.Delete(knownBadResourcesFile);
         _knownBadResources.Clear();
     }
-
+    
+    /// <summary>
+    /// Gets the count of known bad resources
+    /// </summary>
+    /// <returns></returns>
+    public int GetKnownBadResourceCount() => _knownBadResources.Count;
+    
     private void SaveKnownBadResources()
     {
         if (_knownBadResources.Count == 0) return;

--- a/src/CSharp App/Services/CacheService.cs
+++ b/src/CSharp App/Services/CacheService.cs
@@ -37,6 +37,7 @@ public partial class CacheService
     private LightningDatabase _moddedDatabase;
     private LightningDatabase _vanillaBoundsDatabase;
     private LightningDatabase _moddedBoundsDatabase;
+    private readonly HashSet<string> _knownBadResources = new();
     private bool _isInitialized;
 
     public bool IsInitialized
@@ -49,6 +50,7 @@ public partial class CacheService
     {
         Initialize();
     }
+    
     public static CacheService Instance
     {
         get
@@ -89,11 +91,14 @@ public partial class CacheService
             _vanillaBoundsDatabase = tx.OpenDatabase(CacheDatabases.VanillaBounds.ToString(), new DatabaseConfiguration() { Flags = DatabaseOpenFlags.Create });
             tx.Commit();
             
+            LoadKnownBadResources();
+            
             var metaData = GetMetadata();
             if (!ValidationService.ValidateCache(metaData, _settings.GameDirectory, _settings.MinimumCacheVersion))
             {
                 Logger.Warning("Cache is stale, resetting database");
                 ClearMetaData();
+                ClearKnownBadResources();
                 ClearDatabase(CacheDatabases.All, true);
             }
             _isInitialized = true;
@@ -585,6 +590,33 @@ public partial class CacheService
         var metaDataFilePath = Path.Combine(_settings.CacheDirectory, "metadata.json");
         if (File.Exists(metaDataFilePath))
             File.Delete(metaDataFilePath);
+    }
+    
+    /// <summary>
+    /// Deletes the cache metadata file if it exists
+    /// </summary>
+    public void ClearKnownBadResources()
+    {
+        var knownBadResourcesFile = Path.Combine(_settings.CacheDirectory, "knownBadResources.txt");
+        if (File.Exists(knownBadResourcesFile))
+            File.Delete(knownBadResourcesFile);
+        _knownBadResources.Clear();
+    }
+
+    private void SaveKnownBadResources()
+    {
+        if (_knownBadResources.Count == 0) return;
+        var knownBadResourcesFile = Path.Combine(_settings.CacheDirectory, "knownBadResources.txt");
+        File.WriteAllLines(knownBadResourcesFile, _knownBadResources);
+    }
+
+    private void LoadKnownBadResources()
+    {
+        var knownBadResourcesFile = Path.Combine(_settings.CacheDirectory, "knownBadResources.txt");
+        if (!File.Exists(knownBadResourcesFile))
+            return;
+        foreach (var line in File.ReadAllLines(knownBadResourcesFile))
+            _knownBadResources.Add(line);
     }
     
     /// <summary>

--- a/src/CSharp App/Services/CacheServiceRW.cs
+++ b/src/CSharp App/Services/CacheServiceRW.cs
@@ -268,4 +268,21 @@ public partial class CacheService
             Logger.Success("Finished writing all queued entries to cache");
         }
     }
+    
+    /// <summary>
+    /// Checks if the resource path has failed before (thus being "bad")
+    /// </summary>
+    /// <param name="resourcePath">Resource path to check</param>
+    /// <returns></returns>
+    public bool IsResourceKnownBad(string resourcePath) => _knownBadResources.Contains(resourcePath);
+
+    /// <summary>
+    /// Adds the resource path to the known bad list
+    /// </summary>
+    /// <param name="resourcePath">Resource path to add</param>
+    public void AddKnownBadResource(string resourcePath)
+    {
+        if (_knownBadResources.Add(resourcePath))
+            SaveKnownBadResources();
+    }
 }

--- a/src/CSharp App/Services/GameFileService.cs
+++ b/src/CSharp App/Services/GameFileService.cs
@@ -153,7 +153,7 @@ public class GameFileService
             return token;
         }
 
-        if (_cacheService.IsResourceKnownBad(path))
+        if (_cacheService.IsResourceKnownBad(path) && _settingsService.RememberFailedResources)
         {
             token.Result = ResourceTokenResult.KnownBad;
             return token;
@@ -224,7 +224,7 @@ public class GameFileService
             return token;
         }
         
-        if (_cacheService.IsResourceKnownBad(path))
+        if (_cacheService.IsResourceKnownBad(path) && _settingsService.RememberFailedResources)
         {
             token.Result = ResourceTokenResult.KnownBad;
             return token;

--- a/src/CSharp App/Services/GameFileService.cs
+++ b/src/CSharp App/Services/GameFileService.cs
@@ -153,7 +153,7 @@ public class GameFileService
             return token;
         }
 
-        if (_cacheService.IsResourceKnownBad(path) && _settingsService.RememberFailedResources)
+        if (_settingsService.RememberFailedResources && _cacheService.IsResourceKnownBad(path))
         {
             token.Result = ResourceTokenResult.KnownBad;
             return token;
@@ -224,7 +224,7 @@ public class GameFileService
             return token;
         }
         
-        if (_cacheService.IsResourceKnownBad(path) && _settingsService.RememberFailedResources)
+        if (_settingsService.RememberFailedResources && _cacheService.IsResourceKnownBad(path))
         {
             token.Result = ResourceTokenResult.KnownBad;
             return token;

--- a/src/CSharp App/Services/GameFileService.cs
+++ b/src/CSharp App/Services/GameFileService.cs
@@ -138,11 +138,22 @@ public class GameFileService
     {
         if (!_initialized) throw new Exception("GameFileService must be initialized before calling GetCMesh.");
 
+        if (_cacheService.IsResourceKnownBad(path))
+        {
+            Logger.Warning($"Skipping known bad mesh {path}");
+            return null;
+        }
+        
         var cachedMesh = _cacheService.GetEntry(new ReadCacheRequest(path, _readCacheTarget));
         if (MessagePackHelper.TryDeserialize<AbbrMesh>(cachedMesh, out var mesh)) return mesh;
         
         var rawMesh = ArchiveManager.GetCR2WFile(path);
-        if (rawMesh == null) return null;
+        if (rawMesh == null)
+        {
+            _cacheService.AddKnownBadResource(path);
+            Logger.Warning($"Failed to get mesh {path}, marking as known bad.");
+            return null;
+        }
         CacheDatabases db = CacheDatabases.Vanilla;
         if (_settingsService.SupportModdedResources)
         {
@@ -157,7 +168,8 @@ public class GameFileService
         }
         catch (Exception ex)
         {
-            Logger.Exception(ex,$"Failed to parse mesh {path}");
+            Logger.Exception(ex,$"Failed to parse mesh {path}, marked as known bad.");
+            _cacheService.AddKnownBadResource(path);
             return null;
         }
         if (parsedMesh == null) return null;
@@ -177,14 +189,26 @@ public class GameFileService
     public AbbrSector? GetSector(string path)
     {
         if (!_initialized) throw new Exception("GameFileService must be initialized before calling GetCMesh.");
-        var cachedSector = _cacheService.GetEntry(new ReadCacheRequest(path, _readCacheTarget));
-        if (MessagePackHelper.TryDeserialize<AbbrSector>(cachedSector, out var mesh))
+        
+        if (_cacheService.IsResourceKnownBad(path))
         {
-            return mesh;
+            Logger.Warning($"Skipping known bad sector {path}");
+            return null;
+        }
+        
+        var cachedSector = _cacheService.GetEntry(new ReadCacheRequest(path, _readCacheTarget));
+        if (MessagePackHelper.TryDeserialize<AbbrSector>(cachedSector, out var sector))
+        {
+            return sector;
         }
         
         var rawSector = ArchiveManager.GetCR2WFile(path);
-        if (rawSector == null) return null;
+        if (rawSector == null)
+        {
+            _cacheService.AddKnownBadResource(path);
+            Logger.Warning($"Failed to get sector {path}, marking as known bad. ");
+            return null;
+        }
         CacheDatabases db = CacheDatabases.Vanilla;
         if (_settingsService.SupportModdedResources)
         {
@@ -199,7 +223,8 @@ public class GameFileService
         }
         catch (Exception ex)
         {
-            Logger.Exception(ex,$"Failed to parse sector {path}");
+            Logger.Exception(ex,$"Failed to parse sector {path}, marked as known bad.");
+            _cacheService.AddKnownBadResource(path);
             return null;
         }
 

--- a/src/CSharp App/Services/GameFileService.cs
+++ b/src/CSharp App/Services/GameFileService.cs
@@ -114,18 +114,28 @@ public class GameFileService
     /// <param name="sectorHash"></param>
     /// <param name="actorHash"></param>
     /// <returns></returns>
-    /// <exception cref="Exception">Game file service is not initialized</exception>
     /// <remarks>Collision meshes are not cached</remarks>
-    public async Task<AbbrMesh?> GetPhysXMesh(ulong sectorHash, ulong actorHash)
+    public async Task<ResourceToken> GetPhysXMesh(ulong sectorHash, ulong actorHash)
     {
-        if (!_initialized) throw new Exception("GameFileService must be initialized before calling GetPhysXMesh.");
+        var token = new ResourceToken();
+        
+        if (!_initialized)
+        {
+            token.Result = ResourceTokenResult.NotInitialized;
+            return token;
+        }
+        
         var rawMesh = await _geometryCacheService.GetEntryAsync(sectorHash, actorHash);
         if (rawMesh == null)
         {
-            return null;
+            token.Result = ResourceTokenResult.Failure;
+            return token;
         }
         
-        return DirectAbbrMeshParser.ParseFromPhysX(rawMesh);
+        token.Result = ResourceTokenResult.Success;
+        token.Resource = DirectAbbrMeshParser.ParseFromPhysX(rawMesh);
+
+        return token;
     }
     
     /// <summary>
@@ -133,26 +143,36 @@ public class GameFileService
     /// </summary>
     /// <param name="path"></param>
     /// <returns></returns>
-    /// <exception cref="Exception">Game file service is not initialized</exception>
-    public AbbrMesh? GetCMesh(string path)
+    public ResourceToken GetCMesh(string path)
     {
-        if (!_initialized) throw new Exception("GameFileService must be initialized before calling GetCMesh.");
+        var token = new ResourceToken();
+
+        if (!_initialized)
+        {
+            token.Result = ResourceTokenResult.NotInitialized;
+            return token;
+        }
 
         if (_cacheService.IsResourceKnownBad(path))
         {
-            Logger.Warning($"Skipping known bad mesh {path}");
-            return null;
+            token.Result = ResourceTokenResult.KnownBad;
+            return token;
         }
         
         var cachedMesh = _cacheService.GetEntry(new ReadCacheRequest(path, _readCacheTarget));
-        if (MessagePackHelper.TryDeserialize<AbbrMesh>(cachedMesh, out var mesh)) return mesh;
+        if (MessagePackHelper.TryDeserialize<AbbrMesh>(cachedMesh, out var mesh))
+        {
+            token.Result = ResourceTokenResult.Success;
+            token.Resource = mesh;
+            return token;
+        }
         
         var rawMesh = ArchiveManager.GetCR2WFile(path);
         if (rawMesh == null)
         {
             _cacheService.AddKnownBadResource(path);
-            Logger.Warning($"Failed to get mesh {path}, marking as known bad.");
-            return null;
+            token.Result = ResourceTokenResult.Failure;
+            return token;
         }
         CacheDatabases db = CacheDatabases.Vanilla;
         if (_settingsService.SupportModdedResources)
@@ -168,16 +188,25 @@ public class GameFileService
         }
         catch (Exception ex)
         {
-            Logger.Exception(ex,$"Failed to parse mesh {path}, marked as known bad.");
+            Logger.Exception(ex,$"Failed to parse mesh {path}");
             _cacheService.AddKnownBadResource(path);
-            return null;
+            token.Result = ResourceTokenResult.Failure;
+            return token;
         }
-        if (parsedMesh == null) return null;
 
-        if (!_settingsService.CacheModdedResources && db == CacheDatabases.Modded) return parsedMesh;
-        _cacheService.WriteEntry(path, parsedMesh, db); 
+        if (parsedMesh == null)
+        {
+            token.Result = ResourceTokenResult.Failure;
+            return token;
+        }
         
-        return parsedMesh;
+        token.Result = ResourceTokenResult.Success;
+        token.Resource = parsedMesh;
+
+        if (db != CacheDatabases.Modded || _settingsService.CacheModdedResources)
+            _cacheService.WriteEntry(path, parsedMesh, db); 
+        
+        return token;
     }
     
     /// <summary>
@@ -185,29 +214,36 @@ public class GameFileService
     /// </summary>
     /// <param name="path"></param>
     /// <returns></returns>
-    /// <exception cref="Exception">Game file service is not initialized</exception>
-    public AbbrSector? GetSector(string path)
+    public ResourceToken GetSector(string path)
     {
-        if (!_initialized) throw new Exception("GameFileService must be initialized before calling GetCMesh.");
+        var token = new ResourceToken();
+
+        if (!_initialized)
+        {
+            token.Result = ResourceTokenResult.NotInitialized;
+            return token;
+        }
         
         if (_cacheService.IsResourceKnownBad(path))
         {
-            Logger.Warning($"Skipping known bad sector {path}");
-            return null;
+            token.Result = ResourceTokenResult.KnownBad;
+            return token;
         }
         
         var cachedSector = _cacheService.GetEntry(new ReadCacheRequest(path, _readCacheTarget));
         if (MessagePackHelper.TryDeserialize<AbbrSector>(cachedSector, out var sector))
         {
-            return sector;
+            token.Result = ResourceTokenResult.Success;
+            token.Resource = sector;
+            return token;
         }
         
         var rawSector = ArchiveManager.GetCR2WFile(path);
         if (rawSector == null)
         {
             _cacheService.AddKnownBadResource(path);
-            Logger.Warning($"Failed to get sector {path}, marking as known bad. ");
-            return null;
+            token.Result = ResourceTokenResult.Failure;
+            return token;
         }
         CacheDatabases db = CacheDatabases.Vanilla;
         if (_settingsService.SupportModdedResources)
@@ -223,13 +259,18 @@ public class GameFileService
         }
         catch (Exception ex)
         {
-            Logger.Exception(ex,$"Failed to parse sector {path}, marked as known bad.");
+            Logger.Exception(ex,$"Failed to parse sector {path}");
             _cacheService.AddKnownBadResource(path);
-            return null;
+            token.Result = ResourceTokenResult.Failure;
+            return token;
         }
-
-        if (!_settingsService.CacheModdedResources && db == CacheDatabases.Modded) return parsedSector;
-        _cacheService.WriteEntry(path, parsedSector, db);
-        return parsedSector;
+        
+        token.Result = ResourceTokenResult.Success;
+        token.Resource = parsedSector;
+        
+        if (db != CacheDatabases.Modded || _settingsService.CacheModdedResources)
+            _cacheService.WriteEntry(path, parsedSector, db);
+        
+        return token;
     }
 }

--- a/src/CSharp App/Services/ProcessService.cs
+++ b/src/CSharp App/Services/ProcessService.cs
@@ -9,6 +9,7 @@ using MessagePack;
 using VEnums = VolumetricSelection2077.Enums;
 using WEnums = WolvenKit.RED4.Types.Enums;
 using SharpDX;
+using WolvenKit.Common.PhysX;
 
 namespace VolumetricSelection2077.Services;
 
@@ -103,10 +104,17 @@ public class ProcessService
         try
         {
             string streamingSectorNameFix = Regex.Replace(streamingSectorName, @"\\{2}", @"\");
-            var sector = _gameFileService.GetSector(streamingSectorNameFix);
-            if (sector == null)
+            var sectorToken = _gameFileService.GetSector(streamingSectorNameFix);
+            if (sectorToken.Resource is not AbbrSector sector)
             {
-                Logger.Warning($"Failed to find sector {streamingSectorNameFix}");
+                switch (sectorToken.Result)
+                {
+                    case VEnums.ResourceTokenResult.KnownBad: Logger.Warning($"Sector {streamingSectorName} is a known bad resource, skipping..."); break;
+                    case VEnums.ResourceTokenResult.Success: Logger.Error($"Received an unexpected resource type {sectorToken.Resource?.GetType()} for sector {streamingSectorName}"); break;
+                    case VEnums.ResourceTokenResult.Failure: Logger.Error($"Failed to get sector {streamingSectorName}"); break;
+                    case VEnums.ResourceTokenResult.NotInitialized: Logger.Error($"GameFileService not initialized, cannot get sector {streamingSectorName}"); break;
+                    default: Logger.Error($"Unknown resource token result {sectorToken.Result} for sector {streamingSectorName}"); break;
+                }
                 return null;
             }
                 
@@ -219,10 +227,17 @@ public class ProcessService
                 if (!isInstanced && _settings.SaveFileFormat == VEnums.SaveFileFormat.WorldBuilder)
                     isInstanced = nodeEntry.Type is VEnums.NodeTypeProcessingOptions.worldFoliageNode;
                 
-                var mesh = _gameFileService.GetCMesh(nodeEntry.ResourcePath);
-                if (mesh == null)
+                var meshToken = _gameFileService.GetCMesh(nodeEntry.ResourcePath);
+                if (meshToken.Resource is not AbbrMesh mesh)
                 {
-                    Logger.Warning($"Failed to get CMesh from {nodeEntry.ResourcePath}");
+                    switch (meshToken.Result)
+                    {
+                        case VEnums.ResourceTokenResult.KnownBad: Logger.Warning($"Mesh {nodeEntry.ResourcePath} is a known bad resource, skipping..."); break;
+                        case VEnums.ResourceTokenResult.Success: Logger.Warning($"Received an unexpected resource type {meshToken.Resource?.GetType()} for mesh {nodeEntry.ResourcePath}"); break;
+                        case VEnums.ResourceTokenResult.Failure: Logger.Warning($"Failed to get mesh {nodeEntry.ResourcePath}"); break;
+                        case VEnums.ResourceTokenResult.NotInitialized: Logger.Error($"GameFileService not initialized, cannot get mesh {nodeEntry.ResourcePath}"); break;
+                        default: Logger.Warning($"Unknown resource token result {meshToken.Result} for mesh {nodeEntry.ResourcePath}"); break;
+                    }
                     return null;
                 }
                 var (isInside, instances) = CollisionCheckService.IsMeshInsideBox(mesh,
@@ -262,10 +277,17 @@ public class ProcessService
                         {
                             case WEnums.physicsShapeType.TriangleMesh:
                             case WEnums.physicsShapeType.ConvexMesh:
-                                var collisionMesh = await _gameFileService.GetPhysXMesh((ulong)sectorHash, (ulong)shape.Hash);
-                                if (collisionMesh == null)
+                                var collisionMeshToken = await _gameFileService.GetPhysXMesh((ulong)sectorHash, (ulong)shape.Hash);
+                                if (collisionMeshToken.Resource is not AbbrMesh collisionMesh)
                                 {
-                                    Logger.Warning($"Failed to get PhysX Mesh from {sectorHash} : {shape.Hash}");
+                                    switch (collisionMeshToken.Result)
+                                    {
+                                        case VEnums.ResourceTokenResult.KnownBad: Logger.Warning($"Collision mesh at sector hash {sectorHash} : shape hash {shape.Hash} is a known bad resource, skipping..."); break;
+                                        case VEnums.ResourceTokenResult.Success: Logger.Warning($"Received an unexpected resource type {collisionMeshToken.Resource?.GetType()} for sector hash {sectorHash} : shape hash {shape.Hash}"); break;
+                                        case VEnums.ResourceTokenResult.Failure: Logger.Warning($"Failed to get collision mesh at sector hash {sectorHash} : shape hash {shape.Hash}"); break;
+                                        case VEnums.ResourceTokenResult.NotInitialized: Logger.Error($"GameFileService not initialized, cannot get collision mesh at sector hash {sectorHash} : shape hash {shape.Hash}"); break;
+                                        default: Logger.Warning($"Unknown resource token result {collisionMeshToken.Result} for collision mesh at sector hash {sectorHash} : shape hash {shape.Hash}"); break;
+                                    }
                                     continue;
                                 }
                                 bool isCollisionMeshInsideBox = CollisionCheckService.IsCollisonMeshInsideSelectionBox(collisionMesh, selectionBox.Obb, selectionBox.Aabb, transformActor, shape.Transform);

--- a/src/CSharp App/Services/SettingsService.cs
+++ b/src/CSharp App/Services/SettingsService.cs
@@ -51,6 +51,7 @@ public partial class SettingsService : ObservableObject
         BackupDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "VolumetricSelection2077", "OutputBackup");
         MaxBackupFiles = 10;
         AutoScrollLogViewer = true;
+        RememberFailedResources = true;
     }
     
     public static SettingsService Instance
@@ -111,6 +112,8 @@ public partial class SettingsService : ObservableObject
     public int MaxBackupFiles { get; set; }
     public bool AutoScrollLogViewer { get; set; }
     public string LogDirectory { get; } = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "VolumetricSelection2077", "Logs");
+    
+    public bool RememberFailedResources { get; set; }
 
     #region ExperimentalSettings
 
@@ -195,6 +198,8 @@ public partial class SettingsService : ObservableObject
                 
                 DebugMode = j.Value<bool?>(nameof(DebugMode)) ?? DebugMode;
                 ProxyMeshTreatment = (Enums.ExperimentalSettingsEnum.ProxyMeshTreatment?)j.Value<long?>(nameof(ProxyMeshTreatment)) ?? ProxyMeshTreatment;
+                
+                RememberFailedResources = j.Value<bool?>(nameof(RememberFailedResources)) ?? RememberFailedResources;
                 
             }
             catch (Exception ex)

--- a/src/CSharp App/TestingStuff/BuildKnownBadSectorVerbose.cs
+++ b/src/CSharp App/TestingStuff/BuildKnownBadSectorVerbose.cs
@@ -26,10 +26,17 @@ public class BuildKnownBadSectorVerbose : IDebugTool
         try
         {
             Logger.Info($"Building bounds for {sectorPath}...");
-            var sector = _gameFileService.GetSector(sectorPath);
-            if (sector == null)
+            var sectorToken = _gameFileService.GetSector(sectorPath);
+            if (sectorToken.Resource is not AbbrSector sector)
             {
-                Logger.Warning($"Failed to get sector {sectorPath}");
+                switch (sectorToken.Result)
+                {
+                    case ResourceTokenResult.KnownBad: Logger.Warning($"Sector {sectorPath} is a known bad resource, skipping..."); break;
+                    case ResourceTokenResult.Success: Logger.Error($"Received an unexpected resource type {sectorToken.Resource?.GetType()} for sector {sectorPath}"); break;
+                    case ResourceTokenResult.Failure: Logger.Error($"Failed to get sector {sectorPath}"); break;
+                    case ResourceTokenResult.NotInitialized: Logger.Error($"GameFileService not initialized, cannot get sector {sectorPath}"); break;
+                    default: Logger.Error($"Unknown resource token result {sectorToken.Result} for sector {sectorPath}"); break;
+                }
                 return;
             }
 
@@ -42,10 +49,17 @@ public class BuildKnownBadSectorVerbose : IDebugTool
                 
                 if ((nodeEntry?.ResourcePath?.EndsWith(".mesh") ?? false) || (nodeEntry?.ResourcePath?.EndsWith(".w2mesh") ?? false))
                 {
-                    var mesh = _gameFileService.GetCMesh(nodeEntry.ResourcePath);
-                    if (mesh == null)
+                    var meshToken = _gameFileService.GetCMesh(nodeEntry.ResourcePath);
+                    if (meshToken.Resource is not AbbrMesh mesh)
                     {
-                        Logger.Warning($"Failed to get CMesh from {nodeEntry.ResourcePath}, using only position data");
+                        switch (meshToken.Result)
+                        {
+                            case ResourceTokenResult.KnownBad: Logger.Warning($"Mesh {nodeEntry.ResourcePath} is a known bad resource, using only position data"); break;
+                            case ResourceTokenResult.Success: Logger.Warning($"Received an unexpected resource type {meshToken.Resource?.GetType()} for mesh {nodeEntry.ResourcePath}, using only position data"); break;
+                            case ResourceTokenResult.Failure: Logger.Warning($"Failed to get mesh {nodeEntry.ResourcePath}, using only position data"); break;
+                            case ResourceTokenResult.NotInitialized: Logger.Error($"GameFileService not initialized, cannot get mesh {nodeEntry.ResourcePath}, using only position data"); break;
+                            default: Logger.Warning($"Unknown resource token result {meshToken.Result} for mesh {nodeEntry.ResourcePath}, using only position data"); break;
+                        }
                         foreach (var transform in nodeDataEntry.Transforms)
                         {
                             min = Vector3.Min(min, transform.Position);
@@ -89,12 +103,28 @@ public class BuildKnownBadSectorVerbose : IDebugTool
                             {
                                 case WEnums.physicsShapeType.TriangleMesh:
                                 case WEnums.physicsShapeType.ConvexMesh:
-                                    var collisionMesh = await _gameFileService.GetPhysXMesh((ulong)nodeEntry.SectorHash,
-                                        (ulong)shape.Hash);
-                                    if (collisionMesh == null)
+                                    if (nodeEntry.SectorHash is not ulong sectorHash ||
+                                        shape.Hash is not ulong shapeHash)
                                     {
-                                        Logger.Warning(
-                                            $"Failed to get PhysX Mesh from {(ulong)nodeEntry.SectorHash} : {shape.Hash}, using only position data");
+                                        Logger.Warning($"Node Data entry contains invalid sector hash {nodeEntry.SectorHash} or shape hash {shape.Hash}, using only position data");
+                                        var combinedPosition = shape.Transform.Position + actor.Transform.Position;
+                                        min = Vector3.Min(min, combinedPosition);
+                                        max = Vector3.Max(max, combinedPosition);
+                                        continue;
+                                    }
+                                    
+                                    var collisionMeshToken = await _gameFileService.GetPhysXMesh(sectorHash,
+                                        shapeHash);
+                                    if (collisionMeshToken.Resource is not AbbrMesh collisionMesh)
+                                    {
+                                        switch (collisionMeshToken.Result)
+                                        {
+                                            case ResourceTokenResult.KnownBad: Logger.Warning($"Collision mesh at sector hash {sectorHash} : shape hash {shapeHash} is a known bad resource, using only position data"); break;
+                                            case ResourceTokenResult.Success: Logger.Warning($"Received an unexpected resource type {collisionMeshToken.Resource?.GetType()} for sector hash {sectorHash} : shape hash {shapeHash}, using only position data"); break;
+                                            case ResourceTokenResult.Failure: Logger.Warning($"Failed to get collision mesh at sector hash {sectorHash} : shape hash {shapeHash}, using only position data"); break;
+                                            case ResourceTokenResult.NotInitialized: Logger.Error($"GameFileService not initialized, cannot get collision mesh at sector hash {sectorHash} : shape hash {shapeHash}"); break;
+                                            default: Logger.Warning($"Unknown resource token result {collisionMeshToken.Result} for collision mesh at sector hash {sectorHash} : shape hash {shapeHash}, using only position data"); break;
+                                        }
                                         var combinedPosition = shape.Transform.Position + actor.Transform.Position;
                                         min = Vector3.Min(min, combinedPosition);
                                         max = Vector3.Max(max, combinedPosition);

--- a/src/CSharp App/TestingStuff/TestCache.cs
+++ b/src/CSharp App/TestingStuff/TestCache.cs
@@ -32,7 +32,7 @@ public class TestCache : IDebugTool
         AbbrMesh? regularCMesh = null;
         try
         { 
-            regularCMesh = gfs.GetCMesh(testMeshPath);
+            regularCMesh = gfs.GetCMesh(testMeshPath).Resource as AbbrMesh;
         }
         catch (Exception e)
         {
@@ -48,7 +48,7 @@ public class TestCache : IDebugTool
         var swGetMeshCache = new Stopwatch();
         swGetMeshCache.Start();
         
-        var cachedCMesh = gfs.GetCMesh(testMeshPath);
+        var cachedCMesh = gfs.GetCMesh(testMeshPath).Resource as AbbrMesh;
 
         swGetMeshCache.Stop();
         Logger.Info($"Got CMesh cached time: {swGetMeshCache.ElapsedMilliseconds} ms");
@@ -58,7 +58,7 @@ public class TestCache : IDebugTool
         var swGetSectorReg = new Stopwatch();
         swGetSectorReg.Start();
         
-        var regularSector = gfs.GetSector(testSectorPath);
+        var regularSector = gfs.GetSector(testSectorPath).Resource as AbbrSector;
 
         swGetSectorReg.Stop();
         Logger.Info($"Got Sector regular time: {swGetSectorReg.ElapsedMilliseconds} ms");
@@ -69,7 +69,7 @@ public class TestCache : IDebugTool
         var swGetSectorCache = new Stopwatch();
         swGetSectorCache.Start();
         
-        var cachedSector = gfs.GetSector(testSectorPath);
+        var cachedSector = gfs.GetSector(testSectorPath).Resource as AbbrSector;
 
         swGetSectorCache.Stop();
         Logger.Info($"Got Sector cached time: {swGetSectorCache.ElapsedMilliseconds} ms");

--- a/src/CSharp App/ViewModels/SettingsViewModel.cs
+++ b/src/CSharp App/ViewModels/SettingsViewModel.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Avalonia;
 using Avalonia.Media.Imaging;
 using Avalonia.Platform;
@@ -75,6 +76,18 @@ namespace VolumetricSelection2077.ViewModels
         
         public bool CacheButtonsAvailable => !CacheWorking;
         public Bitmap SettingsIcon { get; set; }
+
+        public bool RememberFailedResources
+        {
+            get => Settings.RememberFailedResources;
+            set
+            {
+                Settings.RememberFailedResources = value;
+                OnPropertyChanged(nameof(RememberFailedResources));
+            }
+        }
+        
+        public string ClearKnownBadResourcesLabel => $"{Labels.RememberFailedResources} [ {CacheService.Instance.GetKnownBadResourceCount()} resource paths ]";
         
         public SettingsViewModel() 
         { 
@@ -102,6 +115,11 @@ namespace VolumetricSelection2077.ViewModels
 
             ProxyMeshTreatmentOptions = new(Enum.GetValues(typeof(Enums.ExperimentalSettingsEnum.ProxyMeshTreatment))
                 .Cast<Enums.ExperimentalSettingsEnum.ProxyMeshTreatment>());
+        }
+
+        public void RaiseOnPropertyChanged([CallerMemberName] string? propertyName = null)
+        {
+            OnPropertyChanged(propertyName);
         }
    }
 }

--- a/src/CSharp App/Views/SettingsWindow.axaml
+++ b/src/CSharp App/Views/SettingsWindow.axaml
@@ -30,7 +30,7 @@
                     <Grid
                         ColumnDefinitions="200,*"
                         Margin="-10,0"
-                        RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+                        RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
                         <!--  First Row: Label  -->
                         <TextBlock
                             Grid.Column="0"
@@ -102,12 +102,20 @@
                             Grid.Row="10"
                             HorizontalAlignment="Left"
                             Margin="5"
+                            Text="Remember Failed Resources"
+                            ToolTip.Tip="{x:Static resources:ToolTips.RememberFailedResources}"
+                            VerticalAlignment="Center" />
+                        <TextBlock
+                            Grid.Column="0"
+                            Grid.Row="11"
+                            HorizontalAlignment="Left"
+                            Margin="5"
                             Text="{x:Static resources:Labels.CustomSelectionFilePath}"
                             ToolTip.Tip="{x:Static resources:ToolTips.CustomSelectionFilePath}"
                             VerticalAlignment="Center" />
                         <TextBlock
                             Grid.Column="0"
-                            Grid.Row="11"
+                            Grid.Row="12"
                             HorizontalAlignment="Left"
                             Margin="5"
                             Text="{x:Static resources:Labels.BackupDirectory}"
@@ -115,7 +123,7 @@
                             VerticalAlignment="Center" />
                         <TextBlock
                             Grid.Column="0"
-                            Grid.Row="12"
+                            Grid.Row="13"
                             HorizontalAlignment="Left"
                             Margin="5"
                             Text="{x:Static resources:Labels.MaxBackupFiles}"
@@ -343,9 +351,34 @@
                             </Grid>
                         </Grid>
                         <Grid
+                            Grid.Column="1"
+                            Grid.ColumnDefinitions="Auto,*"
+                            Grid.Row="10">
+                            <ToggleSwitch
+                                Grid.Column="0"
+                                IsChecked="{Binding RememberFailedResources}"
+                                Margin="5"
+                                OffContent=""
+                                OnContent="" />
+                            <Button
+                                Background="#ad0002"
+                                Click="ClearKnownBadResources_Click"
+                                Content="{Binding ClearKnownBadResourcesLabel}"
+                                Grid.Column="1"
+                                HorizontalAlignment="Stretch"
+                                HorizontalContentAlignment="Center"
+                                Margin="5,0,5,0">
+                                <Button.Styles>
+                                    <Style Selector="Button:pointerover /template/ ContentPresenter">
+                                        <Setter Property="Background" Value="DarkRed" />
+                                    </Style>
+                                </Button.Styles>
+                            </Button>
+                        </Grid>
+                        <Grid
                             ColumnDefinitions="*, Auto"
                             Grid.Column="1"
-                            Grid.Row="10"
+                            Grid.Row="11"
                             RowDefinitions="Auto">
                             <TextBox
                                 Grid.Column="0"
@@ -371,7 +404,7 @@
                         <Grid
                             ColumnDefinitions="*, Auto"
                             Grid.Column="1"
-                            Grid.Row="11"
+                            Grid.Row="12"
                             RowDefinitions="Auto">
                             <TextBox
                                 Grid.Column="0"
@@ -396,7 +429,7 @@
                         </Grid>
                         <controls:Int32TextBox
                             Grid.Column="1"
-                            Grid.Row="12"
+                            Grid.Row="13"
                             Margin="5"
                             Text="{Binding Settings.MaxBackupFiles, UpdateSourceTrigger=LostFocus}"
                             Watermark="{x:Static resources:Labels.MaxBackupFiles}" />

--- a/src/CSharp App/Views/SettingsWindow.axaml.cs
+++ b/src/CSharp App/Views/SettingsWindow.axaml.cs
@@ -160,5 +160,11 @@ namespace VolumetricSelection2077.Views
                 RestartApp();
             CacheService.Instance.Initialize();
         }
+
+        private void ClearKnownBadResources_Click(object? sender, RoutedEventArgs e)
+        {
+            CacheService.Instance.ClearKnownBadResources();
+            _settingsViewModel.RaiseOnPropertyChanged("ClearKnownBadResourcesLabel");
+        }
     };
 }


### PR DESCRIPTION
## Feat skip known bad sectors
### Adds
* System to remember failed resources to avoid reattempting (e.g. some sectors are expected to fail and decompressing them each time is silly when we already know they won't parse)

### Refactor
* GameFileService now returns a token with the requested resource and a result enum for better communication 
