### PR TITLE
Collision Meshes For WorldBuilder

### DIFF
--- a/src/CSharp App/Converters/Complex/AxlRemovalToWorldBuilderConverter.cs
+++ b/src/CSharp App/Converters/Complex/AxlRemovalToWorldBuilderConverter.cs
@@ -668,7 +668,7 @@ public class AxlRemovalToWorldBuilderConverter
                                 if (css.Materials.Count != 0)
                                     cssMatIndex = _collisionGenerics.Materials.IndexOf(css.Materials[0].GetResolvedText());
 
-                                var cssShape = 0;
+                                int cssShape;
                                 var cssScale = new WorldBuilder.Structs.Vector3();
                                 switch (css.ShapeType.GetEnumValue())
                                 {
@@ -681,9 +681,9 @@ public class AxlRemovalToWorldBuilderConverter
                                         break;
                                     case WEnums.physicsShapeType.Capsule:
                                         cssShape = 1;
-                                        cssScale.x = css.Size.Y * actor.Scale.Y;
-                                        cssScale.y = css.Size.Y * actor.Scale.Y;
-                                        cssScale.z = css.Size.Z * actor.Scale.Z;
+                                        cssScale.x = css.Size.X * actor.Scale.X;
+                                        cssScale.y = css.Size.X * actor.Scale.X;
+                                        cssScale.z = css.Size.Y * actor.Scale.Y;
                                         break;
                                     case WEnums.physicsShapeType.Sphere:
                                         cssShape = 2;
@@ -810,9 +810,10 @@ public class AxlRemovalToWorldBuilderConverter
         PopulateSpawnable(ref se, nde);
         
         // only working way to apply actor and shape transform
-        Matrix shapeTransformMatrix = Matrix.Scaling(new SharpDX.Vector3(1, 1, 1)) * 
-                                      Matrix.RotationQuaternion(WolvenkitToSharpDXConverter.Quaternion(cs.Rotation)) * 
-                                      Matrix.Translation(WolvenkitToSharpDXConverter.Vector3(cs.Position));
+        Matrix shapeTransformMatrix = Matrix.Scaling(new SharpDX.Vector3(1, 1, 1)) *
+                                      Matrix.RotationQuaternion(WolvenkitToSharpDXConverter.Quaternion(cs.Rotation)) *
+                                      Matrix.Translation(WolvenkitToSharpDXConverter.Vector3(cs.Position) *
+                                                         WolvenkitToSharpDXConverter.Vector3(ca.Scale));
 
         Matrix actorTransformMatrix = Matrix.Scaling(new SharpDX.Vector3(1, 1, 1)) * 
                                       Matrix.RotationQuaternion(WolvenkitToSharpDXConverter.Quaternion(ca.Orientation)) * 

--- a/src/CSharp App/Converters/Complex/AxlRemovalToWorldBuilderConverter.cs
+++ b/src/CSharp App/Converters/Complex/AxlRemovalToWorldBuilderConverter.cs
@@ -4,10 +4,13 @@ using System.Linq;
 using DynamicData;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using SharpDX;
+using VolumetricSelection2077.Converters.Simple;
 using VolumetricSelection2077.Enums;
 using VolumetricSelection2077.Enums.ExperimentalSettingsEnum;
 using VolumetricSelection2077.Models;
 using VolumetricSelection2077.Models.WorldBuilder.Editor;
+using VolumetricSelection2077.Models.WorldBuilder.Spawn.Collision;
 using VolumetricSelection2077.Models.WorldBuilder.Spawn.Entity;
 using VolumetricSelection2077.Models.WorldBuilder.Spawn.Light;
 using VolumetricSelection2077.Models.WorldBuilder.Spawn.Mesh;
@@ -18,7 +21,12 @@ using WolvenKit.RED4.Archive.CR2W;
 using WolvenKit.RED4.CR2W.JSON;
 using WolvenKit.RED4.Types;
 using Activator = System.Activator;
+using Collision = VolumetricSelection2077.Models.WorldBuilder.Spawn.Collision.Collision;
+using Quaternion = WolvenKit.RED4.Types.Quaternion;
+using Vector3 = WolvenKit.RED4.Types.Vector3;
 using Vector4 = SharpDX.Vector4;
+using WEnums = WolvenKit.RED4.Types.Enums;
+using WorldBuilder = VolumetricSelection2077.models.WorldBuilder;
 
 namespace VolumetricSelection2077.Converters.Complex;
 
@@ -28,6 +36,7 @@ public class AxlRemovalToWorldBuilderConverter
     private List<string> _warnedTypes;
     private Dictionary<string, List<string>> _embeddedResourcePaths;
     private SettingsService _settings;
+    private CollisionGenerics? _collisionGenerics;
     
     public AxlRemovalToWorldBuilderConverter()
     {
@@ -609,7 +618,113 @@ public class AxlRemovalToWorldBuilderConverter
                 
                 spawnableElements.Add(spawnableMeshNode);
                 break;
+            case worldCollisionNode collisionNode:
+                if (_settings.WorldBuilderCollisionSupport == CollisionWorldBuilderTreatment.Ignore)
+                    goto NotSupported;
+
+                if (collisionNode.CompiledData.Data is not CollisionBuffer cb)
+                {
+                    Logger.Warning("Collision node buffer is not CollisionBuffer. Skipping...");
+                    break;
+                }
+                
+                _collisionGenerics ??= new();
+
+                var ai = 0;
+                foreach (var actor in cb.Actors)
+                {
+                    if (!remNode?.ActorDeletions?.Contains(ai++) ?? true)
+                        continue;
+                    
+                    foreach (var shape in actor.Shapes)
+                    {
+                        switch (shape)
+                        {
+                            case CollisionShapeMesh csm:
+                                var csmMatIndex = 1;
+                                if (csm.Materials.Count != 0)
+                                    csmMatIndex = _collisionGenerics.Materials.IndexOf(csm.Materials[0].GetResolvedText());
+                                
+                                var csmSpawnable = new SpawnableElement()
+                                {
+                                    Name =
+                                        $"{collisionNode.DebugName} {cb.Actors.IndexOf(actor)} {actor.Shapes.IndexOf(shape)} {GetShapeTypeID(csm.ShapeType)}",
+                                    Spawnable = new MeshCollision()
+                                    {
+                                        SectorHash = collisionNode.SectorHash.ToString(),
+                                        ShapeHash = csm.Hash.ToString(),
+                                        MeshType = GetShapeTypeID(csm.ShapeType),
+                                        
+                                        // Material = csmMatIndex,
+                                        // Preset = _collisionGenerics.Presets.IndexOf(csm.Preset.GetResolvedText())
+                                    }
+                                };
+                                
+                                PopulateSpawnable(ref csmSpawnable, nodeDataEntry, actor, shape);
+                                spawnableElements.Add(csmSpawnable);
+                                break;
+                            case CollisionShapeSimple css:
+                                var cssMatIndex = 1;
+                                if (css.Materials.Count != 0)
+                                    cssMatIndex = _collisionGenerics.Materials.IndexOf(css.Materials[0].GetResolvedText());
+
+                                var cssShape = 0;
+                                var cssScale = new WorldBuilder.Structs.Vector3();
+                                switch (css.ShapeType.GetEnumValue())
+                                {
+                                    case WEnums.physicsShapeType.Box:
+                                        BoxShape:
+                                        cssShape = 0;
+                                        cssScale.x = css.Size.X * actor.Scale.X;
+                                        cssScale.y = css.Size.Y * actor.Scale.Y;
+                                        cssScale.z = css.Size.Z * actor.Scale.Z;
+                                        break;
+                                    case WEnums.physicsShapeType.Capsule:
+                                        cssShape = 1;
+                                        cssScale.x = css.Size.Y * actor.Scale.Y;
+                                        cssScale.y = css.Size.Y * actor.Scale.Y;
+                                        cssScale.z = css.Size.Z * actor.Scale.Z;
+                                        break;
+                                    case WEnums.physicsShapeType.Sphere:
+                                        cssShape = 2;
+                                        cssScale.x = css.Size.X * actor.Scale.X;
+                                        cssScale.y = css.Size.X * actor.Scale.X;
+                                        cssScale.z = css.Size.X * actor.Scale.X;
+                                        break;
+                                    case WEnums.physicsShapeType.ConvexMesh:
+                                    case WEnums.physicsShapeType.TriangleMesh:
+                                    case WEnums.physicsShapeType.Invalid:
+                                    default:
+                                        Logger.Warning($"Unexpected shape type {css.ShapeType.GetEnumValue()} for simple collision shape. Using Box.");
+                                        goto BoxShape;
+                                }
+                                
+                                
+                                var cssSpawnable = new SpawnableElement()
+                                {
+                                    Name =
+                                        $"{collisionNode.DebugName} {cb.Actors.IndexOf(actor)} {actor.Shapes.IndexOf(shape)} {shape.ShapeType.ToEnumString()}",
+                                    Spawnable = new Collision()
+                                    {
+                                        Shape = cssShape,
+                                        Scale = cssScale
+                                        // Material = cssMatIndex,
+                                        // Preset = _collisionGenerics.Presets.IndexOf(css.Preset.GetResolvedText()),
+                                    }
+                                };
+                                
+                                PopulateSpawnable(ref cssSpawnable, nodeDataEntry, actor, shape);
+                                spawnableElements.Add(cssSpawnable);
+                                break;
+                            default:
+                                Logger.Warning($"Collision shape {shape.GetType()} is not supported. Skipping...");
+                                break;
+                        }
+                    }
+                }
+                break;
             default:
+                NotSupported:
                 var nodeTypeString = node?.GetType().ToString() ?? "";
                 if (!_warnedTypes.Contains(nodeTypeString))
                 {
@@ -621,6 +736,13 @@ public class AxlRemovalToWorldBuilderConverter
         return spawnableElements;
     }
 
+    private static string GetShapeTypeID(WEnums.physicsShapeType shapeType) => shapeType switch
+    {
+        WEnums.physicsShapeType.TriangleMesh => "BV4TriangleMesh",
+        WEnums.physicsShapeType.ConvexMesh => "ConvexMesh",
+        _ => ""
+    };
+    
     private static Dictionary<string, JObject> GetInstanceDataChanges(worldEntityNode entityNode)
     {
         var outDict = new Dictionary<string, JObject>();
@@ -654,7 +776,6 @@ public class AxlRemovalToWorldBuilderConverter
         return outSerialized;
     }
     
-    
     private static void PopulateBaseMesh(ref SpawnableElement se, worldMeshNode meshNode, worldNodeData nodeDataEntry)
     {
         var mesh = (Mesh)se.Spawnable;
@@ -682,6 +803,29 @@ public class AxlRemovalToWorldBuilderConverter
         se.Spawnable.SecondaryRange = nodeDataEntry.UkFloat1;
         se.Spawnable.Uk10 = nodeDataEntry.Uk10;
         se.Spawnable.Uk11 = nodeDataEntry.Uk11;
+    }
+
+    private static void PopulateSpawnable(ref SpawnableElement se, worldNodeData nde, CollisionActor ca, CollisionShape cs)
+    {
+        PopulateSpawnable(ref se, nde);
+        
+        // only working way to apply actor and shape transform
+        Matrix shapeTransformMatrix = Matrix.Scaling(new SharpDX.Vector3(1, 1, 1)) * 
+                                      Matrix.RotationQuaternion(WolvenkitToSharpDXConverter.Quaternion(cs.Rotation)) * 
+                                      Matrix.Translation(WolvenkitToSharpDXConverter.Vector3(cs.Position));
+
+        Matrix actorTransformMatrix = Matrix.Scaling(new SharpDX.Vector3(1, 1, 1)) * 
+                                      Matrix.RotationQuaternion(WolvenkitToSharpDXConverter.Quaternion(ca.Orientation)) * 
+                                      Matrix.Translation(new SharpDX.Vector3(ca.Position.X, ca.Position.Y, ca.Position.Z));
+
+        Matrix transformMatrix = shapeTransformMatrix * actorTransformMatrix;
+        
+        se.Spawnable.Position = new Vector4(
+            transformMatrix.TranslationVector.X, 
+            transformMatrix.TranslationVector.Y,
+            transformMatrix.TranslationVector.Z,
+            0);
+        se.Spawnable.EulerRotation = SharpDX.Quaternion.RotationMatrix(transformMatrix);
     }
 
     private static string GetSpawnableName(worldNode node)

--- a/src/CSharp App/Converters/Complex/AxlRemovalToWorldBuilderConverter.cs
+++ b/src/CSharp App/Converters/Complex/AxlRemovalToWorldBuilderConverter.cs
@@ -22,11 +22,8 @@ using WolvenKit.RED4.CR2W.JSON;
 using WolvenKit.RED4.Types;
 using Activator = System.Activator;
 using Collision = VolumetricSelection2077.Models.WorldBuilder.Spawn.Collision.Collision;
-using Quaternion = WolvenKit.RED4.Types.Quaternion;
-using Vector3 = WolvenKit.RED4.Types.Vector3;
 using Vector4 = SharpDX.Vector4;
 using WEnums = WolvenKit.RED4.Types.Enums;
-using WorldBuilder = VolumetricSelection2077.models.WorldBuilder;
 
 namespace VolumetricSelection2077.Converters.Complex;
 
@@ -656,56 +653,42 @@ public class AxlRemovalToWorldBuilderConverter
                                     }
                                 };
                                 
-                                PopulateSpawnable(ref csmSpawnable, nodeDataEntry, actor, shape);
+                                PopulateSpawnable(ref csmSpawnable, nodeDataEntry, actor, csm);
                                 spawnableElements.Add(csmSpawnable);
                                 break;
                             case CollisionShapeSimple css:
-                                int cssShape;
-                                var cssScale = new WorldBuilder.Structs.Vector3();
-                                switch (css.ShapeType.GetEnumValue())
-                                {
-                                    case WEnums.physicsShapeType.Box:
-                                        BoxShape:
-                                        cssShape = 0;
-                                        cssScale.x = css.Size.X * actor.Scale.X;
-                                        cssScale.y = css.Size.Y * actor.Scale.Y;
-                                        cssScale.z = css.Size.Z * actor.Scale.Z;
-                                        break;
-                                    case WEnums.physicsShapeType.Capsule:
-                                        cssShape = 1;
-                                        cssScale.x = css.Size.X * actor.Scale.X;
-                                        cssScale.y = css.Size.X * actor.Scale.X;
-                                        cssScale.z = css.Size.Y * actor.Scale.Y;
-                                        break;
-                                    case WEnums.physicsShapeType.Sphere:
-                                        cssShape = 2;
-                                        cssScale.x = css.Size.X * actor.Scale.X;
-                                        cssScale.y = css.Size.X * actor.Scale.X;
-                                        cssScale.z = css.Size.X * actor.Scale.X;
-                                        break;
-                                    case WEnums.physicsShapeType.ConvexMesh:
-                                    case WEnums.physicsShapeType.TriangleMesh:
-                                    case WEnums.physicsShapeType.Invalid:
-                                    default:
-                                        Logger.Warning($"Unexpected shape type {css.ShapeType.GetEnumValue()} for simple collision shape. Using Box.");
-                                        goto BoxShape;
-                                }
-                                
-                                
                                 var cssSpawnable = new SpawnableElement()
                                 {
                                     Name =
                                         $"{collisionNode.DebugName} {cb.Actors.IndexOf(actor)} {actor.Shapes.IndexOf(shape)} {GetShapeTypeID(css.ShapeType)}",
                                     Spawnable = new Collision()
                                     {
-                                        Shape = cssShape,
-                                        Scale = cssScale,
                                         Material = GetMaterialIndex(shape),
                                         Preset = GetPresetIndex(shape)
                                     }
                                 };
                                 
-                                PopulateSpawnable(ref cssSpawnable, nodeDataEntry, actor, shape);
+                                PopulateSpawnable(ref cssSpawnable, nodeDataEntry, actor, css);
+                                
+                                var col = (cssSpawnable.Spawnable as Collision)!;
+                                
+                                switch (css.ShapeType.GetEnumValue())
+                                {
+                                    case WEnums.physicsShapeType.Box:
+                                        col.Shape = 0;
+                                        break;
+                                    case WEnums.physicsShapeType.Capsule:
+                                        col.Shape = 1;
+                                        col.Scale.z = col.Scale.y;
+                                        col.Scale.y = col.Scale.x;
+                                        break;
+                                    case WEnums.physicsShapeType.Sphere:
+                                        col.Shape = 2;
+                                        col.Scale.y = col.Scale.x;
+                                        col.Scale.z = col.Scale.x;
+                                        break;
+                                }
+                                
                                 spawnableElements.Add(cssSpawnable);
                                 break;
                             default:
@@ -819,28 +802,71 @@ public class AxlRemovalToWorldBuilderConverter
         se.Spawnable.Uk10 = nodeDataEntry.Uk10;
         se.Spawnable.Uk11 = nodeDataEntry.Uk11;
     }
-
-    private static void PopulateSpawnable(ref SpawnableElement se, worldNodeData nde, CollisionActor ca, CollisionShape cs)
+    
+    private static void PopulateSpawnable(ref SpawnableElement se, worldNodeData nde, CollisionActor ca, CollisionShapeSimple cs)
     {
         PopulateSpawnable(ref se, nde);
         
-        Matrix shapeTransformMatrix = Matrix.Scaling(new SharpDX.Vector3(1, 1, 1)) *
-                                      Matrix.RotationQuaternion(WolvenkitToSharpDXConverter.Quaternion(cs.Rotation)) *
-                                      Matrix.Translation(WolvenkitToSharpDXConverter.Vector3(cs.Position) *
-                                                         WolvenkitToSharpDXConverter.Vector3(ca.Scale));
-
-        Matrix actorTransformMatrix = Matrix.Scaling(new SharpDX.Vector3(1, 1, 1)) * 
-                                      Matrix.RotationQuaternion(WolvenkitToSharpDXConverter.Quaternion(ca.Orientation)) * 
-                                      Matrix.Translation(new SharpDX.Vector3(ca.Position.X, ca.Position.Y, ca.Position.Z));
-
-        Matrix transformMatrix = shapeTransformMatrix * actorTransformMatrix;
+        if (se.Spawnable is not Collision col)
+            return;
         
-        se.Spawnable.Position = new Vector4(
-            transformMatrix.TranslationVector.X, 
-            transformMatrix.TranslationVector.Y,
-            transformMatrix.TranslationVector.Z,
-            0);
-        se.Spawnable.EulerRotation = SharpDX.Quaternion.RotationMatrix(transformMatrix);
+        var shapeTransformMatrix = Matrix.Scaling(new SharpDX.Vector3(1, 1, 1)) *
+                                   Matrix.RotationQuaternion(WolvenkitToSharpDXConverter.Quaternion(cs.Rotation)) *
+                                   Matrix.Translation(WolvenkitToSharpDXConverter.Vector3(cs.Position));
+
+        var actorTransformMatrixWScale = Matrix.Scaling(WolvenkitToSharpDXConverter.Vector3(ca.Scale)) * 
+                                         Matrix.RotationQuaternion(WolvenkitToSharpDXConverter.Quaternion(ca.Orientation)) * 
+                                         Matrix.Translation(new SharpDX.Vector3(ca.Position.X, ca.Position.Y, ca.Position.Z));
+
+        var transformMatrixCombined = shapeTransformMatrix * actorTransformMatrixWScale;
+        
+        var result1 = new SharpDX.Vector3(cs.Size.X * 2f, 0.0f, 0.0f);
+        var result2 = new SharpDX.Vector3(0.0f, cs.Size.Y * 2f, 0.0f);
+        var result3 = new SharpDX.Vector3(0.0f, 0.0f, cs.Size.Z * 2f);
+        SharpDX.Vector3.TransformNormal(ref result1, ref transformMatrixCombined, out result1);
+        SharpDX.Vector3.TransformNormal(ref result2, ref transformMatrixCombined, out result2);
+        SharpDX.Vector3.TransformNormal(ref result3, ref transformMatrixCombined, out result3);
+        var scaledHalfExtends = new SharpDX.Vector3(result1.Length(), result2.Length(), result3.Length()) / 2;
+        
+        // rotation breaks when matrix is calculated with scaling
+        var actorTransformMatrixNoScale = Matrix.Scaling(new SharpDX.Vector3(1, 1, 1)) * 
+                                          Matrix.RotationQuaternion(WolvenkitToSharpDXConverter.Quaternion(ca.Orientation)) * 
+                                          Matrix.Translation(new SharpDX.Vector3(ca.Position.X, ca.Position.Y, ca.Position.Z));
+
+        var transformMatrixNoScale = shapeTransformMatrix * actorTransformMatrixNoScale;
+        
+        col.Position = transformMatrixCombined.TranslationVector;
+        col.EulerRotation = SharpDX.Quaternion.RotationMatrix(transformMatrixNoScale);
+        col.Scale = scaledHalfExtends;
+    }
+    
+    private static void PopulateSpawnable(ref SpawnableElement se, worldNodeData nde, CollisionActor ca, CollisionShapeMesh cs)
+    {
+        PopulateSpawnable(ref se, nde);
+        
+        if (se.Spawnable is not MeshCollision col)
+            return;
+        
+        var shapeTransformMatrix = Matrix.Scaling(new SharpDX.Vector3(1, 1, 1)) *
+                                   Matrix.RotationQuaternion(WolvenkitToSharpDXConverter.Quaternion(cs.Rotation)) *
+                                   Matrix.Translation(WolvenkitToSharpDXConverter.Vector3(cs.Position));
+
+        var actorTransformMatrixWScale = Matrix.Scaling(WolvenkitToSharpDXConverter.Vector3(ca.Scale)) * 
+                                         Matrix.RotationQuaternion(WolvenkitToSharpDXConverter.Quaternion(ca.Orientation)) * 
+                                         Matrix.Translation(new SharpDX.Vector3(ca.Position.X, ca.Position.Y, ca.Position.Z));
+
+        var transformMatrixCombined = shapeTransformMatrix * actorTransformMatrixWScale;
+        
+        // rotation breaks when matrix is calculated with scaling
+        var actorTransformMatrixNoScale = Matrix.Scaling(new SharpDX.Vector3(1, 1, 1)) * 
+                                          Matrix.RotationQuaternion(WolvenkitToSharpDXConverter.Quaternion(ca.Orientation)) * 
+                                          Matrix.Translation(new SharpDX.Vector3(ca.Position.X, ca.Position.Y, ca.Position.Z));
+
+        var transformMatrixNoScale = shapeTransformMatrix * actorTransformMatrixNoScale;
+        
+        col.Position = transformMatrixCombined.TranslationVector;
+        col.EulerRotation = SharpDX.Quaternion.RotationMatrix(transformMatrixNoScale);
+        col.Scale = ca.Scale;
     }
 
     private static string GetSpawnableName(worldNode node)

--- a/src/CSharp App/Converters/Complex/AxlRemovalToWorldBuilderConverter.cs
+++ b/src/CSharp App/Converters/Complex/AxlRemovalToWorldBuilderConverter.cs
@@ -36,7 +36,7 @@ public class AxlRemovalToWorldBuilderConverter
     private List<string> _warnedTypes;
     private Dictionary<string, List<string>> _embeddedResourcePaths;
     private SettingsService _settings;
-    private CollisionGenerics? _collisionGenerics;
+    private CollisionGenerics _collisionGenerics;
     
     public AxlRemovalToWorldBuilderConverter()
     {
@@ -44,6 +44,7 @@ public class AxlRemovalToWorldBuilderConverter
         _warnedTypes = new List<string>();
         _embeddedResourcePaths = new Dictionary<string, List<string>>();
         _settings = SettingsService.Instance;
+        _collisionGenerics = new CollisionGenerics();
     }
 
     public Element Convert(AxlRemovalFile axlFile, string rootName)
@@ -627,8 +628,6 @@ public class AxlRemovalToWorldBuilderConverter
                     Logger.Warning("Collision node buffer is not CollisionBuffer. Skipping...");
                     break;
                 }
-                
-                _collisionGenerics ??= new();
 
                 var ai = 0;
                 foreach (var actor in cb.Actors)
@@ -641,9 +640,6 @@ public class AxlRemovalToWorldBuilderConverter
                         switch (shape)
                         {
                             case CollisionShapeMesh csm:
-                                var csmMatIndex = 1;
-                                if (csm.Materials.Count != 0)
-                                    csmMatIndex = _collisionGenerics.Materials.IndexOf(csm.Materials[0].GetResolvedText());
                                 
                                 var csmSpawnable = new SpawnableElement()
                                 {
@@ -655,8 +651,8 @@ public class AxlRemovalToWorldBuilderConverter
                                         ShapeHash = csm.Hash.ToString(),
                                         MeshType = GetShapeTypeID(csm.ShapeType),
                                         
-                                        // Material = csmMatIndex,
-                                        // Preset = _collisionGenerics.Presets.IndexOf(csm.Preset.GetResolvedText())
+                                        Material = GetMaterialIndex(shape),
+                                        Preset = GetPresetIndex(shape)
                                     }
                                 };
                                 
@@ -664,10 +660,6 @@ public class AxlRemovalToWorldBuilderConverter
                                 spawnableElements.Add(csmSpawnable);
                                 break;
                             case CollisionShapeSimple css:
-                                var cssMatIndex = 1;
-                                if (css.Materials.Count != 0)
-                                    cssMatIndex = _collisionGenerics.Materials.IndexOf(css.Materials[0].GetResolvedText());
-
                                 int cssShape;
                                 var cssScale = new WorldBuilder.Structs.Vector3();
                                 switch (css.ShapeType.GetEnumValue())
@@ -703,13 +695,13 @@ public class AxlRemovalToWorldBuilderConverter
                                 var cssSpawnable = new SpawnableElement()
                                 {
                                     Name =
-                                        $"{collisionNode.DebugName} {cb.Actors.IndexOf(actor)} {actor.Shapes.IndexOf(shape)} {shape.ShapeType.ToEnumString()}",
+                                        $"{collisionNode.DebugName} {cb.Actors.IndexOf(actor)} {actor.Shapes.IndexOf(shape)} {GetShapeTypeID(css.ShapeType)}",
                                     Spawnable = new Collision()
                                     {
                                         Shape = cssShape,
-                                        Scale = cssScale
-                                        // Material = cssMatIndex,
-                                        // Preset = _collisionGenerics.Presets.IndexOf(css.Preset.GetResolvedText()),
+                                        Scale = cssScale,
+                                        Material = GetMaterialIndex(shape),
+                                        Preset = GetPresetIndex(shape)
                                     }
                                 };
                                 
@@ -736,11 +728,34 @@ public class AxlRemovalToWorldBuilderConverter
         return spawnableElements;
     }
 
-    private static string GetShapeTypeID(WEnums.physicsShapeType shapeType) => shapeType switch
+    private int GetMaterialIndex(CollisionShape shape)
+    {
+        var matIndex = -1;
+        if (shape.Materials.Count != 0)
+            matIndex = _collisionGenerics.Materials.IndexOf(shape.Materials[0].GetResolvedText());
+
+        if (matIndex != -1) return matIndex;
+        matIndex = 1;
+        Logger.Warning($"Failed to resolve material {(shape.Materials.Count != 0 ? shape.Materials[0].GetResolvedText() : "")} (Hash: {shape.Materials[0].GetRedHash()}) for collision shape {shape.GetType()}. Using default.");
+
+        return matIndex;
+    }
+
+    private int GetPresetIndex(CollisionShape shape)
+    {
+        var presIndex = _collisionGenerics.Presets.IndexOf(shape.Preset.GetResolvedText());
+
+        if (presIndex != -1) return presIndex;
+        presIndex = 33;
+        Logger.Warning($"Failed to resolve preset {shape.Preset.GetResolvedText()} (Hash: {shape.Preset.GetRedHash()}) for collision shape {shape.GetType()}. Using default.");
+
+        return presIndex;
+    }
+    
+    private static string GetShapeTypeID(CEnum<WEnums.physicsShapeType> shapeType) => shapeType.GetEnumValue() switch
     {
         WEnums.physicsShapeType.TriangleMesh => "BV4TriangleMesh",
-        WEnums.physicsShapeType.ConvexMesh => "ConvexMesh",
-        _ => ""
+        _ => shapeType.ToEnumString()
     };
     
     private static Dictionary<string, JObject> GetInstanceDataChanges(worldEntityNode entityNode)
@@ -809,7 +824,6 @@ public class AxlRemovalToWorldBuilderConverter
     {
         PopulateSpawnable(ref se, nde);
         
-        // only working way to apply actor and shape transform
         Matrix shapeTransformMatrix = Matrix.Scaling(new SharpDX.Vector3(1, 1, 1)) *
                                       Matrix.RotationQuaternion(WolvenkitToSharpDXConverter.Quaternion(cs.Rotation)) *
                                       Matrix.Translation(WolvenkitToSharpDXConverter.Vector3(cs.Position) *

--- a/src/CSharp App/Enums/ExperimentalSettingsEnum/ProxyMeshTreatment.cs
+++ b/src/CSharp App/Enums/ExperimentalSettingsEnum/ProxyMeshTreatment.cs
@@ -5,3 +5,9 @@ public enum ProxyMeshTreatment
     RegularMesh,
     ProxyMesh
 }
+
+public enum CollisionWorldBuilderTreatment
+{
+    Ignore,
+    Use
+}

--- a/src/CSharp App/Enums/ExperimentalSettingsEnum/ProxyMeshTreatment.cs
+++ b/src/CSharp App/Enums/ExperimentalSettingsEnum/ProxyMeshTreatment.cs
@@ -9,5 +9,5 @@ public enum ProxyMeshTreatment
 public enum CollisionWorldBuilderTreatment
 {
     Ignore,
-    Use
+    GenerateSimpleAndMesh
 }

--- a/src/CSharp App/Models/WorldBuilder/Spawn/Collision/Collision.cs
+++ b/src/CSharp App/Models/WorldBuilder/Spawn/Collision/Collision.cs
@@ -1,0 +1,33 @@
+using Newtonsoft.Json;
+using VolumetricSelection2077.models.WorldBuilder.Structs;
+
+namespace VolumetricSelection2077.Models.WorldBuilder.Spawn.Collision;
+
+public class Collision : Spawnable
+{
+    [JsonProperty("shape")]
+    public int Shape { get; set; }
+    
+    [JsonProperty("material")]
+    public int Material { get; set; }
+    
+    [JsonProperty("preset")]
+    public int Preset { get; set; }
+    
+    [JsonProperty("scale")]
+    public Vector3 Scale { get; set; }
+    
+    public Collision()
+    {
+        ModulePath = "collision/collider";
+        NodeType = "worldCollisionNode";
+        Scale = new Vector3(1, 1, 1);
+        
+        Shape = 0;
+        
+        Material = 1;
+        Preset = 33;
+        
+        Uk10 = 1040;
+    }
+}

--- a/src/CSharp App/Models/WorldBuilder/Spawn/Collision/CollisionGenerics.cs
+++ b/src/CSharp App/Models/WorldBuilder/Spawn/Collision/CollisionGenerics.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Linq;
+
+namespace VolumetricSelection2077.Models.WorldBuilder.Spawn.Collision;
+
+public class CollisionGenerics
+{
+    public string[] OriginalMaterials { get; set; }
+    public string[] Materials { get; set; }
+    public string[] Presets { get; set; }
+
+    public CollisionGenerics()
+    {
+        OriginalMaterials =
+        [
+            "meatbag.physmat", "linoleum.physmat", "trash.physmat", "plastic.physmat", "character_armor.physmat",
+            "furniture_upholstery.physmat", "metal_transparent.physmat", "tire_car.physmat", "meat.physmat",
+            "metal_car_pipe_steam.physmat", "character_flesh.physmat", "brick.physmat", "character_flesh_head.physmat",
+            "leaves.physmat", "flesh.physmat", "water.physmat", "plastic_road.physmat", "metal_hollow.physmat",
+            "cyberware_flesh.physmat", "plaster.physmat", "plexiglass.physmat", "character_vr.physmat",
+            "vehicle_chassis.physmat", "sand.physmat", "glass_electronics.physmat", "leaves_stealth.physmat",
+            "tarmac.physmat", "metal_car.physmat", "tiles.physmat", "glass_car.physmat", "grass.physmat",
+            "concrete.physmat", "carpet_techpiercable.physmat", "wood_hedge.physmat", "stone.physmat",
+            "leaves_semitransparent.physmat", "metal_catwalk.physmat", "upholstery_car.physmat",
+            "cyberware_metal.physmat", "paper.physmat", "leather.physmat", "metal_pipe_steam.physmat",
+            "metal_pipe_water.physmat", "metal_semitransparent.physmat", "neon.physmat", "glass_dst.physmat",
+            "plastic_car.physmat", "mud.physmat", "dirt.physmat", "metal_car_pipe_water.physmat",
+            "furniture_leather.physmat", "asphalt.physmat", "wood_bamboo_poles.physmat", "glass_opaque.physmat",
+            "carpet.physmat", "food.physmat", "cyberware_metal_head.physmat", "metal_road.physmat", "wood_tree.physmat",
+            "wood_player_npc_semitransparent.physmat", "wood.physmat", "metal_car_ricochet.physmat",
+            "cardboard.physmat", "wood_crown.physmat", "metal_ricochet.physmat", "plastic_electronics.physmat",
+            "glass_semitransparent.physmat", "metal_painted.physmat", "rubber.physmat", "ceramic.physmat",
+            "glass_bulletproof.physmat", "metal_car_electronics.physmat", "trash_bag.physmat",
+            "character_cyberflesh.physmat", "metal_heavypiercable.physmat", "metal.physmat",
+            "plastic_car_electronics.physmat", "oil_spill.physmat", "fabrics.physmat", "glass.physmat",
+            "metal_techpiercable.physmat", "concrete_water_puddles.physmat", "character_metal.physmat"
+        ];
+        
+        Materials = OriginalMaterials
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ToArray();
+
+        Presets =
+        [
+            "World Dynamic", "Player Collision", "Player Hitbox", "NPC Collision", "NPC Trace Obstacle", "NPC Hitbox",
+            "Big NPC Collision", "Player Blocker", "Block Player and Vehicles", "Vehicle Blocker",
+            "Block PhotoMode Camera", "Ragdoll", "Ragdoll Inner", "RagdollVehicle", "Terrain", "Sight Blocker",
+            "Moving Kinematic", "Interaction Object", "Particle", "Destructible", "Debris", "Debris Cluster",
+            "Foliage Debris", "ItemDrop", "Shooting", "Moving Platform", "Water", "Window", "Device transparent",
+            "Device solid visible", "Vehicle Device", "Environment transparent", "Bullet logic", "World Static",
+            "Simple Environment Collision", "Complex Environment Collision", "Foliage Trunk",
+            "Foliage Trunk Destructible", "Foliage Low Trunk", "Foliage Crown", "Vehicle Part", "Vehicle Proxy",
+            "Vehicle Part Query Only Exception", "Vehicle Chassis", "Chassis Bottom", "Chassis Bottom Traffic",
+            "Vehicle Chassis Traffic", "AV Chassis", "Tank Chassis", "Vehicle Chassis LOD3",
+            "Vehicle Chassis Traffic LOD3", "Tank Chassis LOD3", "Drone", "Prop Interaction", "Nameplate",
+            "Road Barrier Simple Collision", "Road Barrier Complex Collision", "Lootable Corpse", "Spider Tank"
+        ];
+    }
+}

--- a/src/CSharp App/Models/WorldBuilder/Spawn/Collision/MeshCollision.cs
+++ b/src/CSharp App/Models/WorldBuilder/Spawn/Collision/MeshCollision.cs
@@ -1,0 +1,35 @@
+using Newtonsoft.Json;
+
+namespace VolumetricSelection2077.Models.WorldBuilder.Spawn.Collision;
+
+public class MeshCollision : Spawnable
+{
+    [JsonProperty("sectorHash")]
+    public string? SectorHash { get; set; }
+    
+    [JsonProperty("shapeHash")]
+    public string? ShapeHash { get; set; }
+    
+    [JsonProperty("meshType")]
+    public string? MeshType { get; set; }
+    
+    [JsonProperty("material")]
+    public int Material { get; set; }
+    
+    [JsonProperty("preset")]
+    public int Preset { get; set; }
+    
+    public MeshCollision()
+    {
+        DataType = "Collision Mesh";
+        ModulePath = "collision/meshCollider";
+        NodeType = "worldCollisionNode";
+
+        SectorHash = null;
+        ShapeHash = null;
+        MeshType = null;
+        
+        Material = 1;
+        Preset = 33;
+    }
+}

--- a/src/CSharp App/Models/WorldBuilder/Spawn/Collision/MeshCollision.cs
+++ b/src/CSharp App/Models/WorldBuilder/Spawn/Collision/MeshCollision.cs
@@ -1,4 +1,5 @@
 using Newtonsoft.Json;
+using VolumetricSelection2077.models.WorldBuilder.Structs;
 
 namespace VolumetricSelection2077.Models.WorldBuilder.Spawn.Collision;
 
@@ -19,6 +20,9 @@ public class MeshCollision : Spawnable
     [JsonProperty("preset")]
     public int Preset { get; set; }
     
+    [JsonProperty("scale")]
+    public Vector3 Scale { get; set; }   
+    
     public MeshCollision()
     {
         DataType = "Collision Mesh";
@@ -31,5 +35,7 @@ public class MeshCollision : Spawnable
         
         Material = 1;
         Preset = 33;
+        
+        Scale = new Vector3(1,1,1);
     }
 }

--- a/src/CSharp App/Models/WorldBuilder/Structs/EulerAngles.cs
+++ b/src/CSharp App/Models/WorldBuilder/Structs/EulerAngles.cs
@@ -1,10 +1,11 @@
 using System;
+using System.Globalization;
 using VolumetricSelection2077.Converters.Simple;
 using WolvenKit.RED4.Types;
 
 namespace VolumetricSelection2077.models.WorldBuilder.Structs;
 
-public struct EulerAngles
+public class EulerAngles
 {
     public float yaw  { get; set; }
     public float pitch { get; set; }
@@ -16,6 +17,8 @@ public struct EulerAngles
         this.pitch = pitch;
         this.roll  = roll;
     }
+    
+    public EulerAngles() : this(0, 0, 0) { }
     
     public static implicit operator SharpDX.Quaternion(EulerAngles value) => WorldBuilderToSharpDXConverter.Quaternion(value);
     
@@ -52,4 +55,11 @@ public struct EulerAngles
     {
         return HashCode.Combine(yaw, pitch, roll);
     }
+    
+    public override string ToString() =>
+        string.Format(CultureInfo.CurrentCulture, "Yaw:{0} Pitch:{1} Roll:{2}", [
+            yaw,
+            pitch,
+            roll
+        ]);
 }

--- a/src/CSharp App/Models/WorldBuilder/Structs/Vector3.cs
+++ b/src/CSharp App/Models/WorldBuilder/Structs/Vector3.cs
@@ -1,8 +1,9 @@
 using System;
+using System.Globalization;
 
 namespace VolumetricSelection2077.models.WorldBuilder.Structs;
 
-public struct Vector3
+public class Vector3
 {
     public float x;
     public float y;
@@ -14,6 +15,8 @@ public struct Vector3
         this.y = y;
         this.z = z;
     }
+    
+    public Vector3() : this(0, 0, 0) { }
     
     public static implicit operator SharpDX.Vector3(Vector3 value) => new (value.x, value.y, value.z);
     
@@ -41,4 +44,11 @@ public struct Vector3
     {
         return HashCode.Combine(x, y, z);
     }
+
+    public override string ToString() =>
+        string.Format(CultureInfo.CurrentCulture, "X:{0} Y:{1} Z:{2}", [
+            x,
+            y,
+            z
+        ]);
 }

--- a/src/CSharp App/Models/WorldBuilder/Structs/Vector4.cs
+++ b/src/CSharp App/Models/WorldBuilder/Structs/Vector4.cs
@@ -1,8 +1,9 @@
 using System;
+using System.Globalization;
 
 namespace VolumetricSelection2077.models.WorldBuilder.Structs;
 
-public struct Vector4
+public class Vector4
 {
     public float x;
     public float y;
@@ -16,6 +17,8 @@ public struct Vector4
         this.z = z;
         this.w = w;
     }
+
+    public Vector4() : this(0, 0, 0, 1) { }
     
     public static implicit operator SharpDX.Vector4(Vector4 value) => new (value.x, value.y, value.z, value.w);
     
@@ -31,6 +34,19 @@ public struct Vector4
     
     public static implicit operator Vector4(WolvenKit.RED4.Types.Vector4 value) => new (value.X, value.Y, value.Z, value.W);
     
+    public static implicit operator SharpDX.Vector3(Vector4 value) => new (value.x, value.y, value.z);
+    
+    public static implicit operator Vector4(SharpDX.Vector3 value) => new (value.X, value.Y, value.Z, 1);
+    
+    public static implicit operator WolvenKit.RED4.Types.Vector3(Vector4 value) => new ()
+    {
+        X = value.x,
+        Y = value.y,
+        Z = value.z
+    };
+    
+    public static implicit operator Vector4(WolvenKit.RED4.Types.Vector3 value) => new (value.X, value.Y, value.Z, 1);
+    
     public override bool Equals(object? obj)
     {
         if (obj is Vector4 other)
@@ -44,4 +60,12 @@ public struct Vector4
     {
         return HashCode.Combine(x, y, z, w);
     }
+    
+    public override string ToString() =>
+        string.Format(CultureInfo.CurrentCulture, "X:{0} Y:{1} Z:{2} W:{3}", [
+            x,
+            y,
+            z,
+            w
+        ]);
 }

--- a/src/CSharp App/Services/GameFileService.cs
+++ b/src/CSharp App/Services/GameFileService.cs
@@ -11,8 +11,10 @@ using WolvenKit.RED4.CR2W.Archive;
 using WolvenKit.RED4.CR2W;
 using VolumetricSelection2077.MessagePack.Helpers;
 using VolumetricSelection2077.Models;
+using VolumetricSelection2077.Models.WorldBuilder.Spawn.Collision;
 using VolumetricSelection2077.Parsers;
 using WolvenKit.Common;
+using WolvenKit.RED4.Types.Pools;
 
 namespace VolumetricSelection2077.Services;
 
@@ -80,6 +82,8 @@ public class GameFileService
             ArchiveManager.Initialize(gameExePath, _settingsService.SupportModdedResources);
             _cacheService = CacheService.Instance;
             _readCacheTarget = _settingsService.SupportModdedResources ? CacheDatabases.All : CacheDatabases.Vanilla;
+            InitializeCNames();
+            
             _initialized = true;
             sw.Stop();
             Logger.Success($"Initialized Game File Service in {UtilService.FormatElapsedTime(sw.Elapsed)}");
@@ -105,6 +109,23 @@ public class GameFileService
                 }
                 return _instance;
             }
+        }
+    }
+
+    /// <summary>
+    /// Initializes the CNamePool with CNames expected to be encountered.
+    /// </summary>
+    private static void InitializeCNames()
+    {
+        var collisionGenerics = new CollisionGenerics();
+        foreach (var entry in collisionGenerics.OriginalMaterials)
+        {
+            CNamePool.AddOrGetHash(entry);
+        }
+
+        foreach (var entry in collisionGenerics.Presets)
+        {
+            CNamePool.AddOrGetHash(entry);
         }
     }
     

--- a/src/CSharp App/Services/SettingsService.cs
+++ b/src/CSharp App/Services/SettingsService.cs
@@ -117,6 +117,8 @@ public partial class SettingsService : ObservableObject
     [ObservableProperty]
     private bool _debugMode;
     public Enums.ExperimentalSettingsEnum.ProxyMeshTreatment ProxyMeshTreatment { get; set; } = Enums.ExperimentalSettingsEnum.ProxyMeshTreatment.RegularMesh;
+    
+    public Enums.ExperimentalSettingsEnum.CollisionWorldBuilderTreatment WorldBuilderCollisionSupport { get; set; } = Enums.ExperimentalSettingsEnum.CollisionWorldBuilderTreatment.Ignore;
 
     #endregion
     
@@ -195,6 +197,7 @@ public partial class SettingsService : ObservableObject
                 
                 DebugMode = j.Value<bool?>(nameof(DebugMode)) ?? DebugMode;
                 ProxyMeshTreatment = (Enums.ExperimentalSettingsEnum.ProxyMeshTreatment?)j.Value<long?>(nameof(ProxyMeshTreatment)) ?? ProxyMeshTreatment;
+                WorldBuilderCollisionSupport = (Enums.ExperimentalSettingsEnum.CollisionWorldBuilderTreatment?)j.Value<long?>(nameof(WorldBuilderCollisionSupport)) ?? WorldBuilderCollisionSupport;
                 
             }
             catch (Exception ex)

--- a/src/CSharp App/ViewModels/SettingsViewModel.cs
+++ b/src/CSharp App/ViewModels/SettingsViewModel.cs
@@ -19,6 +19,7 @@ namespace VolumetricSelection2077.ViewModels
         private bool _cacheWorking;
         
         public List<Enums.ExperimentalSettingsEnum.ProxyMeshTreatment> ProxyMeshTreatmentOptions { get; set; }
+        public List<Enums.ExperimentalSettingsEnum.CollisionWorldBuilderTreatment> CollisionWorldBuilderTreatmentOptions { get; set; }
 
         [ObservableProperty] 
         private SettingsService _settings;
@@ -102,6 +103,8 @@ namespace VolumetricSelection2077.ViewModels
 
             ProxyMeshTreatmentOptions = new(Enum.GetValues(typeof(Enums.ExperimentalSettingsEnum.ProxyMeshTreatment))
                 .Cast<Enums.ExperimentalSettingsEnum.ProxyMeshTreatment>());
+            CollisionWorldBuilderTreatmentOptions = new(Enum.GetValues(typeof(Enums.ExperimentalSettingsEnum.CollisionWorldBuilderTreatment))
+                .Cast<Enums.ExperimentalSettingsEnum.CollisionWorldBuilderTreatment>());
         }
    }
 }

--- a/src/CSharp App/Views/SettingsWindow.axaml
+++ b/src/CSharp App/Views/SettingsWindow.axaml
@@ -457,6 +457,29 @@
                             Text="Enables export to World Builder as ProxyMesh. Requires WorldBuilder from the main branch at commit f02ad58 (Nov 15th) or later."
                             TextWrapping="Wrap"
                             VerticalAlignment="Center" />
+
+                        <TextBlock
+                            Grid.Column="0"
+                            Grid.Row="4"
+                            HorizontalAlignment="Left"
+                            Margin="5"
+                            Text="Collision Export Treatment"
+                            VerticalAlignment="Center" />
+                        <ComboBox
+                            Grid.Column="1"
+                            Grid.Row="5"
+                            HorizontalAlignment="Stretch"
+                            ItemsSource="{Binding CollisionWorldBuilderTreatmentOptions}"
+                            Margin="5"
+                            SelectedItem="{Binding Settings.WorldBuilderCollisionSupport, Mode=TwoWay}" />
+                        <TextBlock
+                            Grid.Column="1"
+                            Grid.Row="6"
+                            HorizontalAlignment="Left"
+                            Margin="5"
+                            Text="Enables export of collision to World Builder. Requires WorldBuilder from the main branch at commit TBA (currently an open PR) or later."
+                            TextWrapping="Wrap"
+                            VerticalAlignment="Center" />
                     </Grid>
                 </TabItem>
             </TabControl>

--- a/src/CSharp App/Views/SettingsWindow.axaml
+++ b/src/CSharp App/Views/SettingsWindow.axaml
@@ -467,14 +467,14 @@
                             VerticalAlignment="Center" />
                         <ComboBox
                             Grid.Column="1"
-                            Grid.Row="5"
+                            Grid.Row="4"
                             HorizontalAlignment="Stretch"
                             ItemsSource="{Binding CollisionWorldBuilderTreatmentOptions}"
                             Margin="5"
                             SelectedItem="{Binding Settings.WorldBuilderCollisionSupport, Mode=TwoWay}" />
                         <TextBlock
                             Grid.Column="1"
-                            Grid.Row="6"
+                            Grid.Row="5"
                             HorizontalAlignment="Left"
                             Margin="5"
                             Text="Enables export of collision to World Builder. Requires WorldBuilder from the main branch at commit TBA (currently an open PR) or later."


### PR DESCRIPTION
## Collision Meshes For WorldBuilder
### Adds
* Support for generating collision when targeting world builder including simple collision shapes and collision meshes. Has to be enabled in the experimental settings tab as it relies on [unreleased changes in world builder](<https://github.com/justarandomguyintheinternet/CP77_entSpawner/pull/48>)

### Note: 
The wording in the description should be updated once the feature branch is merged into main on the world builder repo