### PR TITLE
remove exp tag for proxy meshes

### DIFF
--- a/src/CSharp App/Converters/Complex/AxlRemovalToWorldBuilderConverter.cs
+++ b/src/CSharp App/Converters/Complex/AxlRemovalToWorldBuilderConverter.cs
@@ -7,7 +7,6 @@ using Newtonsoft.Json.Linq;
 using SharpDX;
 using VolumetricSelection2077.Converters.Simple;
 using VolumetricSelection2077.Enums;
-using VolumetricSelection2077.Enums.ExperimentalSettingsEnum;
 using VolumetricSelection2077.Models;
 using VolumetricSelection2077.Models.WorldBuilder.Editor;
 using VolumetricSelection2077.Models.WorldBuilder.Spawn.Collision;
@@ -586,16 +585,11 @@ public class AxlRemovalToWorldBuilderConverter
                 var spawnablePrefabProxyMeshNode = new SpawnableElement
                 {
                     Name = GetSpawnableName(prefabProxyMeshNode),
-                    Spawnable = new Mesh()
-                };
-
-                if (_settings.ProxyMeshTreatment == ProxyMeshTreatment.ProxyMesh)
-                {
-                    spawnablePrefabProxyMeshNode.Spawnable = new ProxyMesh()
+                    Spawnable = new ProxyMesh()
                     {
                         NearAutoHideDistance = prefabProxyMeshNode.NearAutoHideDistance
-                    };
-                }
+                    }
+                };
                 
                 PopulateBaseMesh(ref spawnablePrefabProxyMeshNode, prefabProxyMeshNode, nodeDataEntry);
                 spawnableElements.Add(spawnablePrefabProxyMeshNode);

--- a/src/CSharp App/Enums/ExperimentalSettingsEnum/ProxyMeshTreatment.cs
+++ b/src/CSharp App/Enums/ExperimentalSettingsEnum/ProxyMeshTreatment.cs
@@ -1,7 +1,0 @@
-namespace VolumetricSelection2077.Enums.ExperimentalSettingsEnum;
-
-public enum ProxyMeshTreatment
-{
-    RegularMesh,
-    ProxyMesh
-} 

--- a/src/CSharp App/Services/SettingsService.cs
+++ b/src/CSharp App/Services/SettingsService.cs
@@ -119,7 +119,6 @@ public partial class SettingsService : ObservableObject
 
     [ObservableProperty]
     private bool _debugMode;
-    public Enums.ExperimentalSettingsEnum.ProxyMeshTreatment ProxyMeshTreatment { get; set; } = Enums.ExperimentalSettingsEnum.ProxyMeshTreatment.RegularMesh;
 
     #endregion
     
@@ -197,7 +196,6 @@ public partial class SettingsService : ObservableObject
                 AutoScrollLogViewer = j.Value<bool?>(nameof(AutoScrollLogViewer)) ?? AutoScrollLogViewer;
                 
                 DebugMode = j.Value<bool?>(nameof(DebugMode)) ?? DebugMode;
-                ProxyMeshTreatment = (Enums.ExperimentalSettingsEnum.ProxyMeshTreatment?)j.Value<long?>(nameof(ProxyMeshTreatment)) ?? ProxyMeshTreatment;
                 
                 RememberFailedResources = j.Value<bool?>(nameof(RememberFailedResources)) ?? RememberFailedResources;
                 

--- a/src/CSharp App/ViewModels/SettingsViewModel.cs
+++ b/src/CSharp App/ViewModels/SettingsViewModel.cs
@@ -18,8 +18,6 @@ namespace VolumetricSelection2077.ViewModels
     { 
         private CacheStats _cacheStats;
         private bool _cacheWorking;
-        
-        public List<Enums.ExperimentalSettingsEnum.ProxyMeshTreatment> ProxyMeshTreatmentOptions { get; set; }
 
         [ObservableProperty] 
         private SettingsService _settings;
@@ -112,9 +110,6 @@ namespace VolumetricSelection2077.ViewModels
                 Logger.Exception(ex, $"Failed to load Settings Icon!");
                 SettingsIcon = new WriteableBitmap(new PixelSize(1,1), new Vector(1,1), PixelFormat.Bgra8888, AlphaFormat.Premul);
             }
-
-            ProxyMeshTreatmentOptions = new(Enum.GetValues(typeof(Enums.ExperimentalSettingsEnum.ProxyMeshTreatment))
-                .Cast<Enums.ExperimentalSettingsEnum.ProxyMeshTreatment>());
         }
 
         public void RaiseOnPropertyChanged([CallerMemberName] string? propertyName = null)

--- a/src/CSharp App/Views/SettingsWindow.axaml
+++ b/src/CSharp App/Views/SettingsWindow.axaml
@@ -467,29 +467,6 @@
                             Text="Enables a hidden menu with some debug and testing functionality. No guarantee is provided for the functionality of debug methods."
                             TextWrapping="Wrap"
                             VerticalAlignment="Center" />
-
-                        <TextBlock
-                            Grid.Column="0"
-                            Grid.Row="2"
-                            HorizontalAlignment="Left"
-                            Margin="5"
-                            Text="Proxy Mesh Treatment"
-                            VerticalAlignment="Center" />
-                        <ComboBox
-                            Grid.Column="1"
-                            Grid.Row="2"
-                            HorizontalAlignment="Stretch"
-                            ItemsSource="{Binding ProxyMeshTreatmentOptions}"
-                            Margin="5"
-                            SelectedItem="{Binding Settings.ProxyMeshTreatment, Mode=TwoWay}" />
-                        <TextBlock
-                            Grid.Column="1"
-                            Grid.Row="3"
-                            HorizontalAlignment="Left"
-                            Margin="5"
-                            Text="Enables export to World Builder as ProxyMesh. Requires WorldBuilder from the main branch at commit f02ad58 (Nov 15th) or later."
-                            TextWrapping="Wrap"
-                            VerticalAlignment="Center" />
                     </Grid>
                 </TabItem>
             </TabControl>


### PR DESCRIPTION
proxy meshes now are always generated as proxy meshes when targeting world builder