### PR TITLE
fix timing based concurrency bug in know bed resources set

### DIFF
--- a/src/CSharp App/Services/CacheService.cs
+++ b/src/CSharp App/Services/CacheService.cs
@@ -33,11 +33,12 @@ public partial class CacheService
     private static readonly ulong EstimatedBoundsEntrySizeInBytes = 116;
     static ConcurrentQueue<WriteCacheRequest> _requestWriteQueue = new();
     private readonly object _lock = new object();
+    private readonly object _saveKnownBadResourcesLock = new();
     private LightningDatabase _vanillaDatabase;
     private LightningDatabase _moddedDatabase;
     private LightningDatabase _vanillaBoundsDatabase;
     private LightningDatabase _moddedBoundsDatabase;
-    private readonly HashSet<string> _knownBadResources = new();
+    private readonly ConcurrentDictionary<string, byte> _knownBadResources = new();
     private bool _isInitialized;
 
     public bool IsInitialized
@@ -146,6 +147,7 @@ public partial class CacheService
     public void StopListening()
     {
         IsProcessing = false;
+        SaveKnownBadResources();
     }
     
     /// <summary>
@@ -610,9 +612,12 @@ public partial class CacheService
     
     private void SaveKnownBadResources()
     {
-        if (_knownBadResources.Count == 0) return;
-        var knownBadResourcesFile = Path.Combine(_settings.CacheDirectory, "knownBadResources.txt");
-        File.WriteAllLines(knownBadResourcesFile, _knownBadResources);
+        lock (_saveKnownBadResourcesLock)
+        {
+            if (_knownBadResources.IsEmpty) return;
+            var knownBadResourcesFile = Path.Combine(_settings.CacheDirectory, "knownBadResources.txt");
+            File.WriteAllLines(knownBadResourcesFile, _knownBadResources.Keys);
+        }
     }
 
     private void LoadKnownBadResources()
@@ -621,7 +626,7 @@ public partial class CacheService
         if (!File.Exists(knownBadResourcesFile))
             return;
         foreach (var line in File.ReadAllLines(knownBadResourcesFile))
-            _knownBadResources.Add(line);
+            _knownBadResources.TryAdd(line, 0);
     }
     
     /// <summary>

--- a/src/CSharp App/Services/CacheServiceRW.cs
+++ b/src/CSharp App/Services/CacheServiceRW.cs
@@ -274,15 +274,11 @@ public partial class CacheService
     /// </summary>
     /// <param name="resourcePath">Resource path to check</param>
     /// <returns></returns>
-    public bool IsResourceKnownBad(string resourcePath) => _knownBadResources.Contains(resourcePath);
+    public bool IsResourceKnownBad(string resourcePath) => _knownBadResources.ContainsKey(resourcePath);
 
     /// <summary>
     /// Adds the resource path to the known bad list
     /// </summary>
     /// <param name="resourcePath">Resource path to add</param>
-    public void AddKnownBadResource(string resourcePath)
-    {
-        if (_knownBadResources.Add(resourcePath))
-            SaveKnownBadResources();
-    }
+    public void AddKnownBadResource(string resourcePath) => _knownBadResources.TryAdd(resourcePath, 0);
 }


### PR DESCRIPTION
## fix timing based concurrency bug in know bed resources set
### Fixes
* Known bad resource set state corrupting when timing is just right and hashset is written to and read from at the same time
* Adjusted when known bad resources are saved to occur when the stop listening method is executed rather than mid run whenever a new bad entry is added 

### Notes
No repro or verification steps due to it's intermittent nature