### PR TITLE
upgrade mpack

### DIFF
--- a/src/CSharp App/VolumetricSelection2077.csproj
+++ b/src/CSharp App/VolumetricSelection2077.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="MathNet.Numerics" Version="6.0.0-beta2" />
     <PackageReference Include="MathNet.Numerics.Signed" Version="5.0.0" />
     <PackageReference Include="MathNet.Spatial" Version="0.6.0" />
-    <PackageReference Include="MessagePack" Version="3.1.3" />
+    <PackageReference Include="MessagePack" Version="3.1.7" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="4.0.1" />
     <PackageReference Include="Octokit" Version="14.0.0" />
     <PackageReference Include="PeNet" Version="5.1.0" />


### PR DESCRIPTION
## upgrade mpack
Closes a possible security vulnerability when using lz compression. 
Didn't affect the project as of now as no compression is used but still better to upgrade now rather than later.